### PR TITLE
Update python_install_opensuse.sh

### DIFF
--- a/install/opensuse/python_install_opensuse.sh
+++ b/install/opensuse/python_install_opensuse.sh
@@ -45,9 +45,9 @@ make |& tee m.txt
 make install |& tee mi.txt
 
 cd $dir
+WHO=$(who am i | sed -e 's/ .*//')
 install_dir=$(readlink -f ../..)
-echo "source $install_dir/profile.bash" >> ~/.bashrc
-
+echo "source $install_dir/profile.bash" >> /home/${WHO}/.bashrc
 # PS1='$ '
 # source ~/.bashrc
 # cd ../..


### PR DESCRIPTION
Fixed bug where adding source line to .bashrc while using sudo in OpenSUSE placed source line in root directory instead of appropriate user.
