### PR TITLE
Fixed memory leak in aacgmConvArr()

### DIFF
--- a/models/aacgm/aacgmlib.c
+++ b/models/aacgm/aacgmlib.c
@@ -55,9 +55,9 @@ aacgm_arr_wrap(PyObject *self, PyObject *args)
 		/* should raise an error here. */
 		if (nElem < 0)	return NULL; /* Not a list */
 		
-		PyObject *latOut = PyList_New(0);
-		PyObject *lonOut = PyList_New(0);
-		PyObject *heightOut = PyList_New(0);
+		PyObject *latOut = PyList_New(nElem);
+		PyObject *lonOut = PyList_New(nElem);
+		PyObject *heightOut = PyList_New(nElem);
 
 		for (i=0; i<nElem; i++) {
 			inlat = PyFloat_AsDouble( PyList_GetItem(latList, i) );
@@ -66,9 +66,9 @@ aacgm_arr_wrap(PyObject *self, PyObject *args)
 			height = PyFloat_AsDouble( PyList_GetItem(heightList, i) );
 			AACGMConvert(inlat, inlon, height, &outLat, &outLon, &r, flg);
 
-			PyList_Append(latOut, PyFloat_FromDouble(outLat)); 
-			PyList_Append(lonOut, PyFloat_FromDouble(outLon));
-			PyList_Append(heightOut, PyFloat_FromDouble(r)); 
+			PyList_SetItem(latOut, i, PyFloat_FromDouble(outLat)); 
+			PyList_SetItem(lonOut, i, PyFloat_FromDouble(outLon));
+			PyList_SetItem(heightOut, i, PyFloat_FromDouble(r)); 
 		}
 		
 		// PyObject *outList = PyList_New(0);
@@ -77,7 +77,7 @@ aacgm_arr_wrap(PyObject *self, PyObject *args)
 		// PyList_Append(outList,PyFloat_FromDouble(outLon));
 		// PyList_Append(outList,PyFloat_FromDouble(height)); 
 		 
-		return Py_BuildValue("OOO", latOut, lonOut, heightOut);
+		return Py_BuildValue("NNN", latOut, lonOut, heightOut);
 	}
 	
 }


### PR DESCRIPTION
Changed PyList_Append to PyList_SetItem since PyList_Append can cause a memory leak (as per http://stackoverflow.com/questions/3512414/does-this-pylist-appendlist-py-buildvalue-leak). Also changed format string of Py_BuildValue from "OOO" to "NNN" since "O" will increment the reference count (http://docs.python.org/release/1.5.2/ext/buildValue.html) and this can cause a memory leak too (http://stackoverflow.com/questions/5508904/c-extension-in-python-return-py-buildvalue-memory-leak-problem).
