### PR TITLE
Remove differences in how figure is generated for show=True vs. show=Fal...

### DIFF
--- a/pydarn/plotting/rti.py
+++ b/pydarn/plotting/rti.py
@@ -218,10 +218,7 @@ def plotRti(sTime,rad,eTime=None,bmnum=7,fileType='fitex',params=['velocity','po
       continue
 
     #get/create a figure
-    if show:
-      rtiFig = plot.figure(figsize=(11,8.5))
-    else:
-      rtiFig = Figure(figsize=(14,14))
+    rtiFig = plot.figure(figsize=(11,8.5))
   
     #give the plot a title
     rtiTitle(rtiFig,sTime,rad,fileType,bmnum)
@@ -318,12 +315,8 @@ def plotRti(sTime,rad,eTime=None,bmnum=7,fileType='fitex',params=['velocity','po
   
     #handle the outputs
     if png == True:
-      if not show:
-        canvas = FigureCanvasAgg(rtiFig)
       rtiFig.savefig(sTime.strftime("%Y%m%d")+'_'+str(tbands[fplot][0])+'_'+str(tbands[fplot][1])+'.'+rad+'.png',dpi=dpi)
     if pdf:
-      if not show:
-        canvas = FigureCanvasAgg(rtiFig)
       rtiFig.savefig(sTime.strftime("%Y%m%d")+'_'+str(tbands[fplot][0])+'_'+str(tbands[fplot][1])+'.'+rad+'.pdf')
     if show:
       rtiFig.show()


### PR DESCRIPTION
...se

Removed unnecessary lines of code that cause unexpected error when show=False and retfig=True are used. The returned figure is not managed by pyplot and is thus unexpectedly difficult to deal with (for example, if fig=pydarn.plotting.rti.plotRti(args, show=False, retfig=True) then fig.show() returns an error). Removing these lines of code fixes this inconsistency.
