### PR TITLE
Installation script corrections on OS X 10.8.5 and MacPorts

### DIFF
--- a/install/mac/python_install_mac_port.sh
+++ b/install/mac/python_install_mac_port.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -v
 
 # Python install script for mac
 # 	installs all pre-requisite software to run DaViT-py
@@ -6,36 +6,33 @@
 
 ver=27
 
-port install python${ver}
-port install py${ver}-pip
-port install py${ver}-ipython
-port install py${ver}-numpy
-port install py${ver}-matplotlib
-port install py${ver}-matplotlib-basemap
-port install py${ver}-scipy
-port install py${ver}-h5py
-port install py${ver}-tornado
-port install py${ver}-zmq
-port install py${ver}-pil
-port install py${ver}-pymongo
-port install py${ver}-paramiko
-port install mpich +gcc47
-port install coreutils
-pip install --upgrade jinja2
-pip install --upgrade cython
-pip install --upgrade scikit-image
-
+port -n install python${ver}
+port -n install py${ver}-pip
+port -n install py${ver}-ipython
+port -n install py${ver}-numpy
+port -n install py${ver}-matplotlib
+port -n install py${ver}-matplotlib-basemap
+port -n install py${ver}-scipy
+port -n install py${ver}-h5py
+port -n install py${ver}-tornado
+port -n install py${ver}-zmq
+port -n install py${ver}-pil
+port -n install py${ver}-pymongo
+port -n install py${ver}-paramiko
+port -n install mpich +gcc47
+port -n install coreutils
 
 dir=$(pwd)
 cd /tmp
 git clone https://github.com/matplotlib/basemap.git
+cd basemap
 python2.7 setup.py install
 
 
 cd $dir
 install_dir=$(greadlink -f ../..)
 echo "source $install_dir/profile.mac" >> ~/.bash_profile
-
+source ~/.bash_profile
 
 cd ../..
 ./mastermake


### PR DESCRIPTION
Added '-n' flag to avoid triggering rebuild of other obsolete/broken ports.
Added '-v' flag to shell script.
Added a "cd" to basemap directory.
Sourced ~/.bash_profile.
NOTE: this appends to .bash_profile so one could end up with multiple sources of the "profile.mac" extra commands.  Harmless but noted.
