### PR TITLE
Fixed inconsistency between dmap.h and dmap.c: use int instead of int32

### DIFF
--- a/pydarn/rst/src/dmap.h
+++ b/pydarn/rst/src/dmap.h
@@ -150,7 +150,7 @@ void *DataMapStoreArray(struct DataMap *ptr,
 int DataMapRemoveArray(struct DataMap *ptr,char *name,int type,int dim);
 
 void *DataMapFindArray(struct DataMap *ptr,char *name,int type,int dim,
-		       int **rng);
+		       int32 **rng);
 
 
 int DataMapSetFreeArray(struct DataMap *ptr,char *name,int type,int dim);


### PR DESCRIPTION
Fixed inconsistency between dmap.h and dmap.c: Changed int to int32 in the prototype for DataMapFindArray in dmap.h. This bug prevents users from being able to install davitpy. Specifically, the "sudo python setup.py install" step fails due to an error from gcc. 

This bug only seems to affect 32-bit systems.

Tested this on a fresh install of 32-bit Ubuntu 14.04 and followed the README.md instructions to install davitpy.
