### PR TITLE
 Add missing __init__.py files

### DIFF
--- a/models/aacgm/__init__.py
+++ b/models/aacgm/__init__.py
@@ -1,0 +1,9 @@
+"""
+*********************
+**Module**: models.aacgm
+*********************
+"""
+try:
+    from aacgm import *
+except Exception, e:
+    print __file__+' -> aacgm: ', e

--- a/pydarn/dmapio/__init__.py
+++ b/pydarn/dmapio/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2012  VT SuperDARN Lab
+# Full license can be found in LICENSE.txt
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+try:
+    from dmapio import *
+except Exception, e:
+    print __file__+' -> dmapio: ', e
+


### PR DESCRIPTION
 These files are needed so that existing import statements continue to
work elsewhere in the tree. For example:
 import models.aacgm   fails without the **init**.py file

This is just a little fallout of restructuring the rst related c code.

 Changes to be committed:
    new file:   models/aacgm/**init**.py
    new file:   pydarn/dmapio/**init**.py
