### PR TITLE
 Make it possible to save the .radar.sqlite file into the DAVIT_TMPDIR

### DIFF
--- a/pydarn/radar/__init__.py
+++ b/pydarn/radar/__init__.py
@@ -37,7 +37,8 @@ except Exception as e:
 # Update local HDF5
 ####################################
 import os.path, time
-dirn = os.environ['HOME']
+try:  dirn = os.environ['DAVIT_TMPDIR']
+except: dirn=os.environ['HOME']
 filn = os.path.join(dirn, '.radars.sqlite')
 ctime = time.time()
 # Update if not there or unreadable

--- a/pydarn/radar/radStruct.py
+++ b/pydarn/radar/radStruct.py
@@ -56,7 +56,11 @@ class network(object):
 
         self.radars = []
         # Get DB name
-        rad_path = os.environ['HOME']
+        try: 
+          rad_path=os.environ['DAVIT_TMPDIR']
+        except:
+          try:  rad_path=os.environ['HOME']
+          except: rad_path = os.path.dirname( os.path.abspath( __file__ ) )
         dbname = os.path.join(rad_path, '.radars.sqlite')
 
         if not os.path.isfile(dbname):
@@ -385,8 +389,11 @@ class radar(object):
 
         # If a radar is requested...
         if code or radId:
-            rad_path = os.environ['HOME']
-            dbname = os.path.join(rad_path, '.radars.sqlite')
+            try: 
+              rad_path=os.environ['DAVIT_TMPDIR']
+            except:
+              rad_path = os.path.dirname( os.path.abspath( __file__ ) )
+            dbname = os.path.join(rad_path, 'radars.sqlite')
 
             if not os.path.isfile(dbname):
                 print "%s not found" % dbname
@@ -595,8 +602,11 @@ class site(object):
         self.maxgate = 0
         self.maxbeam = 0
         if radId or code: 
-            rad_path = os.environ['HOME']
-            dbname = os.path.join(rad_path, '.radars.sqlite')
+            try: 
+              rad_path=os.environ['DAVIT_TMPDIR']
+            except:
+              rad_path = os.path.dirname( os.path.abspath( __file__ ) )
+            dbname = os.path.join(rad_path, 'radars.sqlite')
 
             if not os.path.isfile(dbname):
                 print "%s not found" % dbname


### PR DESCRIPTION
Use the DAVIT_TMPDIR environment variable if defined.
If it is not use the defined HOME directory.

When HOME directories are a network mount, its preferable to stash
reusable davitpy files on a local filesystem for faster access.

 Changes to be committed:
    modified:   pydarn/radar/**init**.py
    modified:   pydarn/radar/radInfoIo.py
    modified:   pydarn/radar/radStruct.py
