### PR TITLE
Wrong module added to start of regex compilation.

### DIFF
--- a/pydarn/sdio/fetchUtils.py
+++ b/pydarn/sdio/fetchUtils.py
@@ -370,6 +370,7 @@ def fetch_remote_files(stime, etime, rad, ftype, method, remotesite,
     import urllib2
 
     import os
+    import re
 
     rn = "fetch_remote_files"
 


### PR DESCRIPTION
urllib was incorrectly added to the start of an re.compile call.
