### PR TITLE
Bug fix: tmp dir not existing so radars.sqlite can't be downloaded.

### DIFF
--- a/pydarn/radar/__init__.py
+++ b/pydarn/radar/__init__.py
@@ -37,8 +37,13 @@ except Exception as e:
 # Update local HDF5
 ####################################
 import os.path, time
-try:  dirn = os.environ['DAVIT_TMPDIR']
-except: dirn=os.environ['HOME']
+try:
+    dirn = os.environ['DAVIT_TMPDIR']
+    d = os.path.dirname(dirn)
+    if not os.path.exists(d):
+        os.makedirs(d)
+except:
+    dirn=os.environ['HOME']
 filn = os.path.join(dirn, '.radars.sqlite')
 ctime = time.time()
 # Update if not there or unreadable


### PR DESCRIPTION
Fixed an error with the temp dir not existing which prevents the radars sqlite file from being updated.

To test this bug fix, 
1) Delete your DAVIT_TMPDIR and then start davitpy. You will receive an error that says: 
"sqlInit() Error unable to open database file: /tmp/sd/.radars.sqlite"
This is a **big** problem because plotting and file reading depends on radars.sqlite being available.
2) From the command line, create your DAVIT_TMPDIR and then restart davitpy, this time you will see a message that says: "Radars information has been updated."
3) Delete your DAVIT_TMPDIR, install this bug fix, and then start davitpy. You won't receive the sqlInit() error.
4) Rejoice!
