### PR TITLE
make overlayCnvCntrs return contour object

### DIFF
--- a/pydarn/plotting/plotMapGrd.py
+++ b/pydarn/plotting/plotMapGrd.py
@@ -518,6 +518,7 @@ class MapConv(object):
             colors = 'DarkSlateGray', linewidths=1., 
             locator=LinearLocator(12) )
         plt.clabel(cntrPlt, inline=1, fontsize=10)
+        return cntrPlt
 
     def overlayHMB(self, hmbCol='Gray'):
         """Overlay Heppnard-Maynard boundary from mapex data


### PR DESCRIPTION
Made overlayCnvCntrs return the plotted contour object. This way, it can be removed like this:

``` python
# plot
mapDatObj = pydarn.plotting.plotMapGrd.MapConv(datetime, mapObj, ax)
contour = mapDatObj.overlayCnvCntrs()

# remove
for x in contour.collections: x.remove()
for x in contour.labelTexts: x.remove()
```

If one's creating an animation/video, removing per-frame elements is an important ability.
