### PR TITLE
make overlayMapFitVel keep track of all plotted vectors

### DIFF
--- a/pydarn/plotting/plotMapGrd.py
+++ b/pydarn/plotting/plotMapGrd.py
@@ -640,6 +640,8 @@ class MapConv(object):
         # get the fitted mlat, mlon, velocity magnitude and azimuth from calcFitCnvVel() function
         ( mlatsPlot, mlonsPlot, velMagn, velAzm ) = self.calcFitCnvVel()
 
+        self.mapFitPltStrt = []
+        self.mapFitPltVec = []
 
         for nn in range( len(mlatsPlot) ) :
 
@@ -667,18 +669,18 @@ class MapConv(object):
             xVecEnd, yVecEnd = self.mObj(endLon, endLat, 
                 coords = self.plotCoords)
 
-            self.mapFitPltStrt = self.mObj.scatter( xVecStrt, yVecStrt, 
+            self.mapFitPltStrt.append(self.mObj.scatter( xVecStrt, yVecStrt, 
                 c=velMagn[nn], s=10.,
                 vmin=0, vmax=self.maxVelPlot, 
                 alpha=0.7, cmap=colMap, zorder=5., 
-                edgecolor='none' )
+                edgecolor='none' ))
 
-            self.mapFitPltVec = self.mObj.plot( [ xVecStrt, xVecEnd ], [ yVecStrt, yVecEnd ], 
-                color = colMap(norm(velMagn[nn])) )
+            self.mapFitPltVec.append(self.mObj.plot( [ xVecStrt, xVecEnd ], [ yVecStrt, yVecEnd ], 
+                color = colMap(norm(velMagn[nn])) ))
 
         # Check and overlay colorbar
         if pltColBar :
-            cbar = matplotlib.pyplot.colorbar(self.mapFitPltStrt, orientation='vertical')
+            cbar = matplotlib.pyplot.colorbar(self.mapFitPltStrt[0], orientation='vertical')
             cbar.set_label('Velocity [m/s]', size = colorBarLabelSize)
         # Check and overlay radnames
         if overlayRadNames :


### PR DESCRIPTION
overlayMapFitVel is currently storing scatters and lines in two attributes `self.mapFitPltStrt` and `self.mapFitPltVec`, but these are overwritten for each iteration of the plotting loop and thus only contain references to a few of the plotted objects.

This branch makes the two attributes lists instead, appending plotted objects throughout the loop. This makes it possible to e.g. remove all the plotted objects (which is useful if iterating and making an animation or similar). The two attributes are not used for anything else throghout the davitpy codebase.

Note that since the type/structure of the attributes change, this will break backwards compatibility if anyone was ever using these for anything. Fixing this is as simple as what I've done on the last edited line (adding an index referencing any single element in the list - or specifically the last one, `[-1]`, if one's really picky). Note also that these two attributes are entirely undocumented and one would have do go digging in the code like I did to find them and figure out how to use them.

**Optional solution:** save all plotted objects to local lists and return them. The function is currently not returning anything, so this will preserve backwards compatibility. I can easily make a pull request for that.
