### PR TITLE
Bugfix for GOES Flare Code

### DIFF
--- a/gme/sat/goes.py
+++ b/gme/sat/goes.py
@@ -448,7 +448,7 @@ def find_flares(goes_data,window_minutes=60,min_class='X1',sTime=None,eTime=None
 
     if drop_list != []:
         flares  = flares.drop(drop_list)
-        flares['class'] = map(classify_flare,flares['B_AVG'])
+    flares['class'] = map(classify_flare,flares['B_AVG'])
 
     return flares
 


### PR DESCRIPTION
**Summary:** Minor bugfix to remove remove an indent that prevents flare class from being added to dataframe if there is only a single flare found.

**Test Code:**

``` python
import datetime, gme
goes_data   = gme.sat.read_goes(datetime.datetime(2013,5,12),datetime.datetime(2013,5,14),15)
flares      = gme.sat.find_flares(goes_data,min_class='X2')
```

After this patch is applied, `flares` will be a dataframe containing both X-ray data and the string of solar flare class.
