### PR TITLE
minor bugfix for GS model FOV overlays

### DIFF
--- a/pydarn/plotting/mapOverlay.py
+++ b/pydarn/plotting/mapOverlay.py
@@ -176,7 +176,8 @@ def overlayFov(mapObj, codes=None, ids=None, names=None,
 	from datetime import datetime as dt
 	from datetime import timedelta
 	import matplotlib.cm as cm
-	from numpy import transpose, ones, concatenate, vstack, shape, nanargmin
+	from numpy import transpose, ones, concatenate, vstack, shape
+        import numpy as np
 	from matplotlib.patches import Polygon
 	from pylab import gca
 	
@@ -240,8 +241,11 @@ def overlayFov(mapObj, codes=None, ids=None, names=None,
                     # Ground scatter model is not defined for close in rangegates.
                     # np.nan will be returned for these gates.
                     # Set sGate >= to the first rangegate that has real values.
-
-                    tmp_sGate = (nanargmin(radFov.lonFull,axis=1)).max()
+                    
+                    not_finite  = np.logical_not(np.isfinite(radFov.lonFull))
+                    grid        = np.tile(np.arange(radFov.lonFull.shape[1]),(radFov.lonFull.shape[0],1)) 
+                    grid[not_finite] = 999999
+                    tmp_sGate   = (np.min(grid,axis=1)).max()
                     if tmp_sGate > sGate: sGate = tmp_sGate
 
 		# Get radar coordinates in map projection


### PR DESCRIPTION
**Summary:** The ground scatter (GS) model is not defined for close-in range gates.  Therefore, FOV objects return np.nan for lat/lons of undefined rangegates.  This case was not handled properly in pydarn.plotting.overlayFov().  This pull request fixes that issue by setting the sGate to greater than the user specified value when the user-specified value would otherwise be invalid.  This pull request only affects pydarn.plotting.overlayFov() and should not interact with other parts of davitpy.

**Example:**

``` python
from matplotlib import pyplot as plt
import datetime
import pydarn
import utils

time   = datetime.datetime(2012,11,15)
lat_0  =  90.0 
lon_0  = -85.0
width  = 45000000
height = 45000000

fig = plt.figure(figsize=(10,8))
ax = fig.add_subplot(111)
m = utils.plotUtils.mapObj(projection='stere',datetime=time,
                           width=width,height=height,
                           lon_0=lon_0,lat_0=lat_0,ax=ax)
pydarn.plotting.overlayFov(m,codes='fhe',dateTime=time,model='GS')

plt.show()
```

Currently on `develop`:
![image](https://cloud.githubusercontent.com/assets/1831182/4682800/ecabcef0-5620-11e4-9e9c-9faa27833456.png)

After this pull request:
![image](https://cloud.githubusercontent.com/assets/1831182/4682815/08a7449a-5621-11e4-96bc-0b7ddf541e8b.png)
