### PR TITLE
Feature plot_iq

### DIFF
--- a/pydarn/plotting/__init__.py
+++ b/pydarn/plotting/__init__.py
@@ -12,12 +12,18 @@ This subpackage contains various plotting routines for DaViT-py
 	* :mod:`fan`
 	* :mod:`pygridPlot`
 	* :mod:`printRec`
+	* :mod:`iqPlot`
 """
 
 try:
 	from rti import *
 except Exception,e: 
 	print 'problem importing rti: ', e
+
+try:
+	from iqPlot import *
+except Exception,e: 
+	print 'problem importing iqPlot: ', e
 
 try:
 	from fan import *

--- a/pydarn/plotting/iqPlot.py
+++ b/pydarn/plotting/iqPlot.py
@@ -178,3 +178,44 @@ def plot_iq(myBeam, sequences=None, mag_phase=False, scale=None, user_ax=None):
     fig.show()
 
 
+
+
+
+
+if __name__ == "__main__":
+
+  import pydarn
+  from matplotlib import pyplot
+  from datetime import datetime
+  
+  print "First we need to fetch an iqdat file and read a beam record..."
+  myPtr = pydarn.sdio.radDataOpen(datetime(2014,7,10), 'sas', fileName='20140710.1000.03.sas.iqdat', fileType='iqdat')
+  myBeam = pydarn.sdio.radDataReadRec(myPtr)
+
+  print "Testing the plot_iq method and it's options...."
+  print "...First test default options..."
+  pydarn.plotting.iqPlot.plot_iq(myBeam)
+
+
+  print "...Second test plotting Magnitude and Phase..."
+  print "      using 'mag_phase = True'"
+  pydarn.plotting.iqPlot.plot_iq(myBeam, mag_phase = "True")
+
+  print "...Third test plotting only one sequence..."
+  print "      using 'sequences=[0]'"
+  pydarn.plotting.iqPlot.plot_iq(myBeam, sequences=[0])
+
+  print "...Fourth test plotting to an existing axis object..."
+  print "      using 'user_ax = ax'"
+  fig = pyplot.figure()
+  ax = fig.add_axes([0.1,0.1,0.8,0.8])
+  pydarn.plotting.iqPlot.plot_iq(myBeam, user_ax = ax)
+
+  print "...Fifth test plotting with a custom scaling. Data should be scaled down a lot..."
+  print "      using 'scale = 1000.'"
+  fig = pyplot.figure()
+  ax = fig.add_axes([0.1,0.1,0.8,0.8])
+  pydarn.plotting.iqPlot.plot_iq(myBeam, scale=1000.)
+
+  pyplot.show()
+    

--- a/pydarn/plotting/iqPlot.py
+++ b/pydarn/plotting/iqPlot.py
@@ -1,0 +1,180 @@
+# Copyright (C) 2012  VT SuperDARN Lab
+# Full license can be found in LICENSE.txt
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+.. module:: iqPlot
+   :synopsis: A module for generating plotting IQ voltage data
+
+.. moduleauthor:: ASR, 20141225
+
+*********************
+**Module**: pydarn.plotting.iqPlot
+*********************
+**Functions**:
+  * :func:`pydarn.plotting.iqPlot.plot_iq`
+"""
+
+def plot_iq(myBeam, sequences=None, mag_phase=False, scale=None, user_ax=None):
+
+  """create an rti plot for a secified radar and time period
+
+  **Args**:
+    * **myBeam** : a beamData object from pydarn.sdio.radDataTypes
+    * **[sequences]**: (list of ints or None) Defines which sequences of 
+                       voltage data to plot. Default is None which plots 
+                       all.
+    * **[mag_phase]**: (boolean) Specifies whether magnitude and phase 
+                       should be plotted instead of real and imaginary.
+    * **[scale]**: (None or float) Specifies the scaling to use on real, 
+                   imaginary, or magnitude axes. Default is None which 
+                   auto-scales.
+    * **[ax]**: a matplotlib axis object
+  **Returns**:
+    Nothing.
+
+  **Example**:
+    ::
+      from datetime import datetime
+      myPtr = pydarn.sdio.radDataOpen(datetime(2014,7,10),'sas',fileType='iqdat')
+      pydarn.plotting.iqPlot.plot_iq(myBeam)
+
+  Written by ASR 20141225
+  """
+
+  from matplotlib import pyplot
+  import numpy as np
+  import pydarn
+  import matplotlib as mpl
+
+  # obtain relevant parameters
+  number_lags = myBeam.prm.mplgs
+  tp = myBeam.prm.txpl
+  rp = myBeam.prm.smsep
+  tau = myBeam.prm.mpinc
+  ltab = myBeam.prm.ltab
+  ptab = myBeam.prm.ptab
+  skpnum = myBeam.iqdat.skpnum
+  seqnum = myBeam.iqdat.seqnum
+  smpnum = myBeam.iqdat.smpnum
+  smsep = myBeam.prm.smsep
+  lagfr = myBeam.prm.lagfr
+
+  # If an axis object is provided, but the sequence number is not,
+  # set sequences so that the first sequence is plotted to the axis 
+  # object
+  if user_ax is not None:
+    if sequences is None:
+      sequences = [0]
+
+  # check input
+  # default to plotting all sequences
+  if sequences is None:
+    sequences = range(0,seqnum)
+
+  # figure out when the tx pulses went out
+  #number of ranges per tau
+  tp_in_tau = tau/tp
+
+  #determine which samples overlap with tx pulses
+  tx_times=[p*tp_in_tau for p in ptab]
+  blanked_samples=[]
+  for tx in tx_times:
+    blanked_samples.extend([tx])
+  
+  # Start plotting
+  if user_ax is None:
+    fig = pyplot.figure(figsize=(11,8.5))
+
+  len_seq = len(sequences)
+  figtop = .88
+  figheight = .82/len_seq
+
+  #plot the iq data for each of the requested pulse sequences
+  for s,seq in enumerate(sequences):
+
+    #calculate the positions of the data axis and colorbar axis 
+    #for the current parameter and then add them to the figure
+    pos = [.1,figtop-figheight*(s+1)+.05,.8,figheight]#-.04]
+    #cpos = [.86,figtop-figheight*(p+1)+.05,.03,figheight-.04]    
+    if user_ax is None:
+      ax = fig.add_axes(pos)
+    else:
+      ax = user_ax
+
+    if (s == 0):
+      rad = pydarn.radar.network().getRadarById(5).code[0]
+      time = myBeam.time.strftime('%H:%M:%S UT %d/%m/%Y')
+      title='Pulse Sequence IQ Data  '+rad+'   Beam '+str(myBeam.bmnum)+'   Tx Freq '+str(myBeam.prm.tfreq)+'kHz   Time: '+ time
+      ax.set_title(title)
+
+    ax.set_xticklabels([])
+    ax.set_yticklabels([])
+
+    sample_nums = range(0,myBeam.iqdat.smpnum)
+
+    iq_real = np.array([x[0] for x in myBeam.iqdat.mainData[seq]])
+    iq_imag = np.array([x[1] for x in myBeam.iqdat.mainData[seq]])
+
+    if (mag_phase):
+      mag = np.sqrt(iq_real**2 + iq_imag**2)
+      phase = np.arctan2(iq_imag,iq_real)
+      if scale is None:
+        scale_const = np.mean(mag)
+      else:
+        scale_const = scale
+      ax.plot(sample_nums, mag/scale_const - np.pi,'k')
+      ax.plot(sample_nums, phase,'r')
+      ax.set_xlim([0,smpnum])
+      ax.set_ylim([-np.pi,np.pi])
+    else:
+      mag = np.sqrt(iq_real**2 + iq_imag**2)
+      if scale is None:
+        scale_const = np.mean(mag)/np.sqrt(2.)
+      else:
+        scale_const = scale
+      ax.plot(sample_nums, iq_real/scale_const,'k')
+      ax.plot(sample_nums, iq_imag/scale_const,'r')
+      ax.set_xlim([0,smpnum])
+      ax.set_ylim([-np.pi,np.pi])
+    ax.set_ylabel(str(seq))
+
+
+  # Now plot when the Tx pulses were sent out
+
+  txs = [1 if (x in blanked_samples) else 0 for x in sample_nums]
+  pos = [.1,figtop-figheight*(len_seq)+.02,.8,0.03]
+
+  if user_ax is None:
+    ax = fig.add_axes(pos)
+
+  # constant for setting the "width" of the Tx pulse
+  const = tp/float(rp)
+  for x in blanked_samples:
+    time = np.array([x, x, x+const, x+const])
+    amp = np.array([0, 1, 1, 0])
+    if user_ax is None:
+      ax.fill(time,amp,color='black')
+      ax.set_ylabel('Tx')
+      ax.set_xlabel('Sample Number')
+      ax.set_xlim([0,smpnum])
+      ax.set_yticklabels([])
+    else:
+      ax.plot(time,amp,color='black')
+
+  if user_ax is None:
+    fig.show()
+
+

--- a/pydarn/plotting/iqPlot.py
+++ b/pydarn/plotting/iqPlot.py
@@ -200,7 +200,7 @@ if __name__ == "__main__":
     from datetime import datetime
   
     print "First we need to fetch an iqdat file and read a beam record..."
-    myPtr = pydarn.sdio.radDataOpen(datetime(2014,7,10), 'sas', fileName='20140710.1000.03.sas.iqdat', fileType='iqdat')
+    myPtr = pydarn.sdio.radDataOpen(datetime(2012,5,21), 'kap', fileType='iqdat')
     myBeam = pydarn.sdio.radDataReadRec(myPtr)
 
     print "Testing the plot_iq method and it's options...."

--- a/pydarn/plotting/iqPlot.py
+++ b/pydarn/plotting/iqPlot.py
@@ -27,195 +27,209 @@
   * :func:`pydarn.plotting.iqPlot.plot_iq`
 """
 
-def plot_iq(myBeam, sequences=None, mag_phase=False, scale=None, user_ax=None):
+def plot_iq(myBeam, sequences=None, mag_phase=False, scale=None, user_ax=None, tx_pulse=True):
 
-  """create an rti plot for a secified radar and time period
+    """create an rti plot for a secified radar and time period
 
-  **Args**:
-    * **myBeam** : a beamData object from pydarn.sdio.radDataTypes
-    * **[sequences]**: (list of ints or None) Defines which sequences of 
-                       voltage data to plot. Default is None which plots 
-                       all.
-    * **[mag_phase]**: (boolean) Specifies whether magnitude and phase 
-                       should be plotted instead of real and imaginary.
-    * **[scale]**: (None or float) Specifies the scaling to use on real, 
-                   imaginary, or magnitude axes. Default is None which 
-                   auto-scales.
-    * **[ax]**: a matplotlib axis object
-  **Returns**:
-    Nothing.
+    **Args**:
+        * **myBeam** : a beamData object from pydarn.sdio.radDataTypes
+        * **[sequences]**: (list of ints or None) Defines which sequences
+                           of voltage data to plot. Default is None which
+                           plots all.
+        * **[mag_phase]**: (boolean) Specifies whether magnitude and 
+                           phase should be plotted instead of real and 
+                           imaginary.
+        * **[scale]**: (None or float) Specifies the scaling to use on 
+                       real, imaginary, or magnitude axes. Default is 
+                       None which auto-scales.
+        * **[ax]**: a matplotlib axis object
+    **Returns**:
+        Nothing.
 
-  **Example**:
-    ::
-      from datetime import datetime
-      myPtr = pydarn.sdio.radDataOpen(datetime(2014,7,10),'sas',fileType='iqdat')
-      pydarn.plotting.iqPlot.plot_iq(myBeam)
+    **Example**:
+        ::
+            from datetime import datetime
+            myPtr = pydarn.sdio.radDataOpen(datetime(2014,7,10), \
+                                            'sas',fileType='iqdat')
+            pydarn.plotting.iqPlot.plot_iq(myBeam)
 
-  Written by ASR 20141225
-  """
+        Written by ASR 20141225
+    """
 
-  from matplotlib import pyplot
-  import numpy as np
-  import pydarn
-  import matplotlib as mpl
+    from matplotlib import pyplot
+    import numpy as np
+    import pydarn
+    import matplotlib as mpl
 
-  # obtain relevant parameters
-  number_lags = myBeam.prm.mplgs
-  tp = myBeam.prm.txpl
-  rp = myBeam.prm.smsep
-  tau = myBeam.prm.mpinc
-  ltab = myBeam.prm.ltab
-  ptab = myBeam.prm.ptab
-  skpnum = myBeam.iqdat.skpnum
-  seqnum = myBeam.iqdat.seqnum
-  smpnum = myBeam.iqdat.smpnum
-  smsep = myBeam.prm.smsep
-  lagfr = myBeam.prm.lagfr
+    # obtain relevant parameters
+    number_lags = myBeam.prm.mplgs
+    tp = myBeam.prm.txpl
+    rp = myBeam.prm.smsep
+    tau = myBeam.prm.mpinc
+    ltab = myBeam.prm.ltab
+    ptab = myBeam.prm.ptab
+    skpnum = myBeam.iqdat.skpnum
+    seqnum = myBeam.iqdat.seqnum
+    smpnum = myBeam.iqdat.smpnum
+    smsep = myBeam.prm.smsep
+    lagfr = myBeam.prm.lagfr
 
-  # If an axis object is provided, but the sequence number is not,
-  # set sequences so that the first sequence is plotted to the axis 
-  # object
-  if user_ax is not None:
+    # If an axis object is provided, but the sequence number is not,
+    # set sequences so that the first sequence is plotted to the axis 
+    # object
+    if user_ax is not None:
+        if sequences is None:
+            sequences = [0]
+
+    # check input
+    # default to plotting all sequences
     if sequences is None:
-      sequences = [0]
+        sequences = range(0,seqnum)
 
-  # check input
-  # default to plotting all sequences
-  if sequences is None:
-    sequences = range(0,seqnum)
+    # figure out when the tx pulses went out
+    #number of ranges per tau
+    tp_in_tau = tau/tp
 
-  # figure out when the tx pulses went out
-  #number of ranges per tau
-  tp_in_tau = tau/tp
-
-  #determine which samples overlap with tx pulses
-  tx_times=[p*tp_in_tau for p in ptab]
-  blanked_samples=[]
-  for tx in tx_times:
-    blanked_samples.extend([tx])
+    #determine which samples overlap with tx pulses
+    tx_times=[p*tp_in_tau for p in ptab]
+    blanked_samples=[]
+    for tx in tx_times:
+        blanked_samples.extend([tx])
   
-  # Start plotting
-  if user_ax is None:
-    fig = pyplot.figure(figsize=(11,8.5))
-
-  len_seq = len(sequences)
-  figtop = .88
-  figheight = .82/len_seq
-
-  #plot the iq data for each of the requested pulse sequences
-  for s,seq in enumerate(sequences):
-
-    #calculate the positions of the data axis and colorbar axis 
-    #for the current parameter and then add them to the figure
-    pos = [.1,figtop-figheight*(s+1)+.05,.8,figheight]#-.04]
-    #cpos = [.86,figtop-figheight*(p+1)+.05,.03,figheight-.04]    
+    # Start plotting
     if user_ax is None:
-      ax = fig.add_axes(pos)
+        fig = pyplot.figure(figsize=(11,8.5))
+
+    len_seq = len(sequences)
+    figtop = .88
+    if ((tx_pulse == False) and (user_ax is None)):
+        figheight = .84/len_seq
     else:
-      ax = user_ax
+        figheight = .82/len_seq
 
-    if (s == 0):
-      rad = pydarn.radar.network().getRadarById(5).code[0]
-      time = myBeam.time.strftime('%H:%M:%S UT %d/%m/%Y')
-      title='Pulse Sequence IQ Data  '+rad+'   Beam '+str(myBeam.bmnum)+'   Tx Freq '+str(myBeam.prm.tfreq)+'kHz   Time: '+ time
-      ax.set_title(title)
+    #plot the iq data for each of the requested pulse sequences
+    for s,seq in enumerate(sequences):
 
-    ax.set_xticklabels([])
-    ax.set_yticklabels([])
+        #calculate the positions of the data axis and colorbar axis 
+        #for the current parameter and then add them to the figure
+        pos = [.1,figtop-figheight*(s+1)+.05,.8,figheight]#-.04]
+        #cpos = [.86,figtop-figheight*(p+1)+.05,.03,figheight-.04]    
+        if user_ax is None:
+            ax = fig.add_axes(pos)
+        else:
+            ax = user_ax
 
-    sample_nums = range(0,myBeam.iqdat.smpnum)
+        if (s == 0):
+            rad = pydarn.radar.network().getRadarById(5).code[0]
+            time = myBeam.time.strftime('%H:%M:%S UT %d/%m/%Y')
+            title='Pulse Sequence IQ Data  '+rad+'   Beam '+ \
+                   str(myBeam.bmnum)+'   Tx Freq '+ \
+                   str(myBeam.prm.tfreq)+'kHz   Time: '+ time
+            ax.set_title(title)
+        if ((s == (len_seq - 1)) and (tx_pulse == False)):
+            ax.set_xlabel('Sample Number')
+        else:
+            ax.set_xticklabels([])
 
-    iq_real = np.array([x[0] for x in myBeam.iqdat.mainData[seq]])
-    iq_imag = np.array([x[1] for x in myBeam.iqdat.mainData[seq]])
+        ax.set_yticklabels([])
 
-    if (mag_phase):
-      mag = np.sqrt(iq_real**2 + iq_imag**2)
-      phase = np.arctan2(iq_imag,iq_real)
-      if scale is None:
-        scale_const = np.mean(mag)
-      else:
-        scale_const = scale
-      ax.plot(sample_nums, mag/scale_const - np.pi,'k')
-      ax.plot(sample_nums, phase,'r')
-      ax.set_xlim([0,smpnum])
-      ax.set_ylim([-np.pi,np.pi])
-    else:
-      mag = np.sqrt(iq_real**2 + iq_imag**2)
-      if scale is None:
-        scale_const = np.mean(mag)/np.sqrt(2.)
-      else:
-        scale_const = scale
-      ax.plot(sample_nums, iq_real/scale_const,'k')
-      ax.plot(sample_nums, iq_imag/scale_const,'r')
-      ax.set_xlim([0,smpnum])
-      ax.set_ylim([-np.pi,np.pi])
-    ax.set_ylabel(str(seq))
+        sample_nums = range(0,myBeam.iqdat.smpnum)
 
+        iq_real = np.array([x[0] for x in myBeam.iqdat.mainData[seq]])
+        iq_imag = np.array([x[1] for x in myBeam.iqdat.mainData[seq]])
 
-  # Now plot when the Tx pulses were sent out
+        if (mag_phase):
+            mag = np.sqrt(iq_real**2 + iq_imag**2)
+            phase = np.arctan2(iq_imag,iq_real)
+            if scale is None:
+                scale_const = np.mean(mag)
+            else:
+                scale_const = scale
+            ax.plot(sample_nums, mag/scale_const - np.pi,'k')
+            ax.plot(sample_nums, phase,'r')
+            ax.set_xlim([0,smpnum])
+            ax.set_ylim([-np.pi,np.pi])
+        else:
+            mag = np.sqrt(iq_real**2 + iq_imag**2)
+            if scale is None:
+                scale_const = np.mean(mag)/np.sqrt(2.)
+            else:
+                scale_const = scale
+            ax.plot(sample_nums, iq_real/scale_const,'k')
+            ax.plot(sample_nums, iq_imag/scale_const,'r')
+            ax.set_xlim([0,smpnum])
+            ax.set_ylim([-np.pi,np.pi])
+        ax.set_ylabel(str(seq))
+    
 
-  txs = [1 if (x in blanked_samples) else 0 for x in sample_nums]
-  pos = [.1,figtop-figheight*(len_seq)+.02,.8,0.03]
-
-  if user_ax is None:
-    ax = fig.add_axes(pos)
-
-  # constant for setting the "width" of the Tx pulse
-  const = tp/float(rp)
-  for x in blanked_samples:
-    time = np.array([x, x, x+const, x+const])
-    amp = np.array([0, 1, 1, 0])
+    if (tx_pulse):
+        # Now plot when the Tx pulses were sent out
+        txs = [1 if (x in blanked_samples) else 0 for x in sample_nums]
+        pos = [.1,figtop-figheight*(len_seq)+.02,.8,0.03]
+    
+        # If a user axis is provided, then plot Tx pulses over 
+        # the voltage data
+        if user_ax is None:
+            ax = fig.add_axes(pos)
+    
+        # constant for setting the "width" of the Tx pulse
+        const = tp/float(rp)
+        for x in blanked_samples:
+            time = np.array([x, x, x+const, x+const])
+            amp = np.array([0, 1, 1, 0])
+            if user_ax is None:
+                ax.fill(time,amp,color='black')
+                ax.set_ylabel('Tx')
+                ax.set_xlabel('Sample Number')
+                ax.set_xlim([0,smpnum])
+                ax.set_yticklabels([])
+            else:
+                ax.plot(time,0.1*amp*np.pi - np.pi,color='blue')
+                ax.fill(time,0.1*amp*np.pi - np.pi,color='blue', alpha = 0.5)
+    
     if user_ax is None:
-      ax.fill(time,amp,color='black')
-      ax.set_ylabel('Tx')
-      ax.set_xlabel('Sample Number')
-      ax.set_xlim([0,smpnum])
-      ax.set_yticklabels([])
-    else:
-      ax.plot(time,amp,color='black')
-
-  if user_ax is None:
-    fig.show()
-
-
+        fig.show()
 
 
 
 
 if __name__ == "__main__":
 
-  import pydarn
-  from matplotlib import pyplot
-  from datetime import datetime
+    import pydarn
+    from matplotlib import pyplot
+    from datetime import datetime
   
-  print "First we need to fetch an iqdat file and read a beam record..."
-  myPtr = pydarn.sdio.radDataOpen(datetime(2014,7,10), 'sas', fileName='20140710.1000.03.sas.iqdat', fileType='iqdat')
-  myBeam = pydarn.sdio.radDataReadRec(myPtr)
+    print "First we need to fetch an iqdat file and read a beam record..."
+    myPtr = pydarn.sdio.radDataOpen(datetime(2014,7,10), 'sas', fileName='20140710.1000.03.sas.iqdat', fileType='iqdat')
+    myBeam = pydarn.sdio.radDataReadRec(myPtr)
 
-  print "Testing the plot_iq method and it's options...."
-  print "...First test default options..."
-  pydarn.plotting.iqPlot.plot_iq(myBeam)
+    print "Testing the plot_iq method and it's options...."
+    print "...First test default options..."
+    pydarn.plotting.iqPlot.plot_iq(myBeam)
 
+    print "...Second test plotting Magnitude and Phase..."
+    print "      using 'mag_phase = True'"
+    pydarn.plotting.iqPlot.plot_iq(myBeam, mag_phase = "True")
 
-  print "...Second test plotting Magnitude and Phase..."
-  print "      using 'mag_phase = True'"
-  pydarn.plotting.iqPlot.plot_iq(myBeam, mag_phase = "True")
+    print "...Third test plotting only one sequence..."
+    print "      using 'sequences=[0]'"
+    pydarn.plotting.iqPlot.plot_iq(myBeam, sequences=[0])
 
-  print "...Third test plotting only one sequence..."
-  print "      using 'sequences=[0]'"
-  pydarn.plotting.iqPlot.plot_iq(myBeam, sequences=[0])
+    print "...Fourth test plotting to an existing axis object..."
+    print "      using 'user_ax = ax'"
+    fig = pyplot.figure()
+    ax = fig.add_axes([0.1,0.1,0.8,0.8])
+    pydarn.plotting.iqPlot.plot_iq(myBeam, user_ax = ax)
 
-  print "...Fourth test plotting to an existing axis object..."
-  print "      using 'user_ax = ax'"
-  fig = pyplot.figure()
-  ax = fig.add_axes([0.1,0.1,0.8,0.8])
-  pydarn.plotting.iqPlot.plot_iq(myBeam, user_ax = ax)
+    print "...Fifth, test the tx_pulse option..."
+    print "      using 'tx_pulse = False.'"
+    pydarn.plotting.iqPlot.plot_iq(myBeam, tx_pulse=False)
 
-  print "...Fifth test plotting with a custom scaling. Data should be scaled down a lot..."
-  print "      using 'scale = 1000.'"
-  fig = pyplot.figure()
-  ax = fig.add_axes([0.1,0.1,0.8,0.8])
-  pydarn.plotting.iqPlot.plot_iq(myBeam, scale=1000.)
+    print "...Sixth test plotting with a custom scaling. Data should be scaled down a lot..."
+    print "      using 'scale = 1000.'"
+    fig = pyplot.figure()
+    ax = fig.add_axes([0.1,0.1,0.8,0.8])
+    pydarn.plotting.iqPlot.plot_iq(myBeam, scale=1000.)
 
-  pyplot.show()
+    pyplot.show()
     

--- a/pydarn/plotting/iqPlot.py
+++ b/pydarn/plotting/iqPlot.py
@@ -27,7 +27,7 @@
   * :func:`pydarn.plotting.iqPlot.plot_iq`
 """
 
-def plot_iq(myBeam, sequences=None, mag_phase=False, scale=None, user_ax=None, tx_pulse=True):
+def plot_iq(myBeam, sequences=None, mag_phase=False, scale=None, user_ax=None, tx_pulse=True, int_data=False):
 
     """create an rti plot for a secified radar and time period
 
@@ -42,7 +42,10 @@ def plot_iq(myBeam, sequences=None, mag_phase=False, scale=None, user_ax=None, t
         * **[scale]**: (None or float) Specifies the scaling to use on 
                        real, imaginary, or magnitude axes. Default is 
                        None which auto-scales.
-        * **[ax]**: a matplotlib axis object
+        * **[user_ax]**: a matplotlib axis object
+        * **[tx_pulse]**: (boolean) Specifies whether or not to plot Tx pulses
+        * **[int_data]**: (boolean) Specifies whether or not to plot voltage samples from the interferometer array (checks beamData.prm.xcf)
+
     **Returns**:
         Nothing.
 
@@ -82,6 +85,11 @@ def plot_iq(myBeam, sequences=None, mag_phase=False, scale=None, user_ax=None, t
             sequences = [0]
 
     # check input
+
+    if ((int_data) and (myBeam.prm.xcf == 0)):
+        print "No interferometer data available."
+        return
+
     # default to plotting all sequences
     if sequences is None:
         sequences = range(0,seqnum)
@@ -135,8 +143,13 @@ def plot_iq(myBeam, sequences=None, mag_phase=False, scale=None, user_ax=None, t
 
         sample_nums = range(0,myBeam.iqdat.smpnum)
 
-        iq_real = np.array([x[0] for x in myBeam.iqdat.mainData[seq]])
-        iq_imag = np.array([x[1] for x in myBeam.iqdat.mainData[seq]])
+        # Get the main or interferometer array data to plot
+        if ((int_data) and (myBeam.prm.xcf == 1)):
+            iq_real = np.array([x[0] for x in myBeam.iqdat.intData[seq]])
+            iq_imag = np.array([x[1] for x in myBeam.iqdat.intData[seq]])
+        else:
+            iq_real = np.array([x[0] for x in myBeam.iqdat.mainData[seq]])
+            iq_imag = np.array([x[1] for x in myBeam.iqdat.mainData[seq]])
 
         if (mag_phase):
             mag = np.sqrt(iq_real**2 + iq_imag**2)

--- a/pydarn/plotting/iqPlot.py
+++ b/pydarn/plotting/iqPlot.py
@@ -120,7 +120,7 @@ def plot_iq(myBeam, sequences=None, mag_phase=False, scale=None, user_ax=None, t
             ax = user_ax
 
         if (s == 0):
-            rad = pydarn.radar.network().getRadarById(5).code[0]
+            rad = pydarn.radar.network().getRadarById(myBeam.stid).code[0]
             time = myBeam.time.strftime('%H:%M:%S UT %d/%m/%Y')
             title='Pulse Sequence IQ Data  '+rad+'   Beam '+ \
                    str(myBeam.bmnum)+'   Tx Freq '+ \
@@ -227,8 +227,6 @@ if __name__ == "__main__":
 
     print "...Sixth test plotting with a custom scaling. Data should be scaled down a lot..."
     print "      using 'scale = 1000.'"
-    fig = pyplot.figure()
-    ax = fig.add_axes([0.1,0.1,0.8,0.8])
     pydarn.plotting.iqPlot.plot_iq(myBeam, scale=1000.)
 
     pyplot.show()

--- a/pydarn/plotting/iqPlot.py
+++ b/pydarn/plotting/iqPlot.py
@@ -43,8 +43,11 @@ def plot_iq(myBeam, sequences=None, mag_phase=False, scale=None, user_ax=None, t
                        real, imaginary, or magnitude axes. Default is 
                        None which auto-scales.
         * **[user_ax]**: a matplotlib axis object
-        * **[tx_pulse]**: (boolean) Specifies whether or not to plot Tx pulses
-        * **[int_data]**: (boolean) Specifies whether or not to plot voltage samples from the interferometer array (checks beamData.prm.xcf)
+        * **[tx_pulse]**: (boolean) Specifies whether or not to plot Tx 
+                          pulses
+        * **[int_data]**: (boolean) Specifies whether or not to plot 
+                          voltage samples from the interferometer array 
+                          (checks beamData.prm.xcf)
 
     **Returns**:
         Nothing.
@@ -52,8 +55,8 @@ def plot_iq(myBeam, sequences=None, mag_phase=False, scale=None, user_ax=None, t
     **Example**:
         ::
             from datetime import datetime
-            myPtr = pydarn.sdio.radDataOpen(datetime(2014,7,10), \
-                                            'sas',fileType='iqdat')
+            myPtr = pydarn.sdio.radDataOpen(datetime(2012,5,21), \
+                                            'kap',fileType='iqdat')
             pydarn.plotting.iqPlot.plot_iq(myBeam)
 
         Written by ASR 20141225
@@ -198,7 +201,8 @@ def plot_iq(myBeam, sequences=None, mag_phase=False, scale=None, user_ax=None, t
                 ax.set_yticklabels([])
             else:
                 ax.plot(time,0.1*amp*np.pi - np.pi,color='blue')
-                ax.fill(time,0.1*amp*np.pi - np.pi,color='blue', alpha = 0.5)
+                ax.fill(time,0.1*amp*np.pi - np.pi,color='blue', \
+                                                    alpha = 0.5)
     
     if user_ax is None:
         fig.show()

--- a/pydarn/sdio/radDataTypes.py
+++ b/pydarn/sdio/radDataTypes.py
@@ -998,19 +998,21 @@ class iqData(radBaseData):
     I'm not sure what all of the attributes mean.  if somebody knows what these are, please help!
 
   **Attrs**:
-    * **chnnum** (int): number of channels?
+    * **chnnum** (int): number of channels sampled
     * **smpnum** (int): number of samples per pulse sequence
-    * **skpnum** (int): number of samples to skip at the beginning of a pulse sequence?
+    * **skpnum** (int): number of voltage samples to skip when making acfs
     * **seqnum** (int): number of pulse sequences
-    * **tbadtr** (? length list): time of bad tr samples?
-    * **tval** (? length list): ?
-    * **atten** (? length list): ?
-    * **noise** (? length list): ?
-    * **offset** (? length list): ?
-    * **size** (? length list): ?
+    * **tsc** (seqnum length list): seconds component of time past epoch of each pulse sequence
+    * **tus** (seqnum length list): micro seconds component of time past epoch of each pulse sequence
+    * **tatten** (seqnum length list): attenuator setting for each pulse sequence
+    * **tnoise** (seqnum length list): noise value for each pulse sequence
+    * **toff** (seqnum length list): offset into the sample buffer for each pulse sequence
+    * **tsze** (seqnum length list): number of words stored per pulse sequence
+    * **mainData** (seqnum x smpnum x 2 length list): the main array iq complex samples
+    * **intData** (seqnum x smpnum x 2 length list): the interferometer iq complex samples
     * **badtr** (? length list): bad tr samples?
-    * **mainData** (seqnum x smpnum x 2 length list): the actual iq samples (main array)
-    * **intData** (seqnum x smpnum x 2 length list): the actual iq samples (interferometer)
+    * **tval** (? length list): ?
+    * **tbadtr** (? length list): time of bad tr samples?
   
   **Example**: 
     ::


### PR DESCRIPTION
Extends `pydarn/plotting` by adding the ability to plot iqdat files. This plotting routine takes a `beamData` object from `pydarn.sdio.radDataTypes` as input and plots the `mainData` I and Q channels. Here are the function's options:

1) sequences: (list of ints or None) Defines which sequences of voltage data to plot. Default is None which plots all.
2) mag_phase: (boolean) Specifies whether magnitude and phase should be plotted instead of real and imaginary.
3) scale: (None or float) Specifies the scaling to use on real, imaginary, or magnitude axes. Default is None which auto-scales.
4) user_ax: a matplotlib axis object
5) tx_pulse: (boolean) Specifies whether or not to plot Tx pulses
6) int_data: (boolean) Specifies whether or not to plot voltage samples from the interferometer array (checks beamData.prm.xcf)

To test the plotting routine, please run: `python iqPlot.py` and read through the output to see if the plots are what they should be. 

Here is an example usage:

    myPtr = pydarn.sdio.radDataOpen(datetime(2012,5,21),'kap',fileType='iqdat')
    myBeam = myPtr.readRec()
    pydarn.plotting.iqPlot.plot_iq(myBeam)

The `__init__.py` file in the `pydarn/plotting` directory was modified to add an import all from iqPlot.py.