### PR TITLE
Feature: Adding plotAcf.py

### DIFF
--- a/pydarn/plotting/__init__.py
+++ b/pydarn/plotting/__init__.py
@@ -12,12 +12,18 @@ This subpackage contains various plotting routines for DaViT-py
 	* :mod:`fan`
 	* :mod:`pygridPlot`
 	* :mod:`printRec`
+	* :mod:`acfPlot`
 """
 
 try:
 	from rti import *
 except Exception,e: 
 	print 'problem importing rti: ', e
+
+try:
+	from acfPlot import *
+except Exception,e: 
+	print 'problem importing acfPlot: ', e
 
 try:
 	from fan import *

--- a/pydarn/plotting/__init__.py
+++ b/pydarn/plotting/__init__.py
@@ -26,6 +26,7 @@ try:
 except Exception,e: 
 	print 'problem importing acfPlot: ', e
 
+try:
 	from iqPlot import *
 except Exception,e: 
 	print 'problem importing iqPlot: ', e

--- a/pydarn/plotting/acfPlot.py
+++ b/pydarn/plotting/acfPlot.py
@@ -32,7 +32,8 @@
 
 
 def plot_acf(myBeam, gate, normalized=True, mark_blanked=True,
-             xcf=False, panel=0, ax=None):
+             xcf=False, panel=0, ax=None, show=True, png=False,
+             pdf=False):
     """
     Plot the ACF/XCF for a specified beamData object at a
     specified range gate
@@ -50,6 +51,10 @@ def plot_acf(myBeam, gate, normalized=True, mark_blanked=True,
                        ACF/XCF, ACF/XCF amplitude, ACF/XCF phase, or
                        power spectrum, respectively. Default is panel=0.
         * **[ax]**: a matplotlib axis object
+        * **[show]**: (boolean) Specifies whether plot to a figure
+                                window. If set to false and png or pdf
+                                are set to false, then the figure is
+                                plotted to a png file.
 
     **Returns**:
         Nothing.
@@ -66,6 +71,8 @@ def plot_acf(myBeam, gate, normalized=True, mark_blanked=True,
     """
 
     from matplotlib import pyplot
+    from matplotlib.backends.backend_agg import FigureCanvasAgg
+    from matplotlib.figure import Figure as mpl_fig
     from matplotlib.ticker import MaxNLocator
     import numpy as np
     import pydarn
@@ -132,7 +139,13 @@ def plot_acf(myBeam, gate, normalized=True, mark_blanked=True,
         lag_numbers.extend(temp)
 
     if ax is None:
-        fig = pyplot.figure()
+        # Make the figure and axes
+        if show:
+            fig = pyplot.figure()
+        else:
+            if (png == False) and (pdf == False):
+                png = True
+            fig = mpl_fig()
         ax1 = fig.add_axes([0.1, 0.55, 0.35, 0.35])
         ax2 = fig.add_axes([0.1, 0.1, 0.35, 0.35])
         ax3 = fig.add_axes([0.5, 0.1, 0.35, 0.35])
@@ -249,8 +262,34 @@ def plot_acf(myBeam, gate, normalized=True, mark_blanked=True,
             ax4.get_yaxis().get_offset_text().set_x(1)
             ax4.yaxis.set_major_locator(MaxNLocator(prune='upper'))
 
-    if ax is None:
+
+    #handle the outputs
+    rad = pydarn.radar.network().getRadarById(myBeam.stid).code[0]
+    if png and (ax is None):
+        if not show:
+            canvas = FigureCanvasAgg(fig)
+        if xcf:
+            fig.savefig('XCF_' +
+                        myBeam.time.strftime("%Y%m%d_%H%M%S_UT") +
+                        '_' + rad +'_gate' + str(gate) + '.png')
+        else:
+            fig.savefig('ACF_' +
+                        myBeam.time.strftime("%Y%m%d_%H%M%S_UT") +
+                        '_' + rad +'_gate' + str(gate) + '.png')
+    if pdf and (ax is None):
+        if not show:
+            canvas = FigureCanvasAgg(fig)
+        if xcf:
+            fig.savefig('XCF_' +
+                        myBeam.time.strftime("%Y%m%d_%H%M%S_UT") +
+                        '_' + rad +'_gate' + str(gate) + '.pdf')
+        else:
+            fig.savefig('ACF_' +
+                        myBeam.time.strftime("%Y%m%d_%H%M%S_UT") +
+                        '_' + rad +'_gate' + str(gate) + '.pdf')
+    if show and (ax is None):
         fig.show()
+
 
 
 def calc_blanked(ltab, tp, tau, tfr, gate):
@@ -325,7 +364,7 @@ def calc_blanked(ltab, tp, tau, tfr, gate):
     return txs_in_lag
 
 
-def plot_rli(myBeam, normalized=True, xcf=False):
+def plot_rli(myBeam, normalized=True, xcf=False, show=True, png=False, pdf=False):
     """
     This function plots a range-lag-intensity plot of ACF/XCF data
     for an input beamData object.
@@ -334,8 +373,12 @@ def plot_rli(myBeam, normalized=True, xcf=False):
         * **myBeam** : A beamData object from pydarn.sdio.radDataTypes.
         * **[normalized]**: (boolean) Specifies whether to normalize the
                             ACF/XCF data by the lag-zero power.
-        * **[xcf]**: (boolean) Specifies wheather to plot XCF data or
+        * **[xcf]**: (boolean) Specifies whether to plot XCF data or
                                not.
+        * **[show]**: (boolean) Specifies whether plot to a figure
+                                window. If set to false and png or pdf
+                                are set to false, then the figure is
+                                plotted to a png file.
 
     **Returns**:
         Nothing.
@@ -352,6 +395,8 @@ def plot_rli(myBeam, normalized=True, xcf=False):
     """
 
     from matplotlib import pyplot
+    from matplotlib.backends.backend_agg import FigureCanvasAgg
+    from matplotlib.figure import Figure as mpl_fig
     import numpy as np
     from matplotlib import colors
     import matplotlib as mpl
@@ -366,7 +411,14 @@ def plot_rli(myBeam, normalized=True, xcf=False):
     noise = np.array(myBeam.prm.noisesearch)
 
     # Make the figure and axes
-    fig = pyplot.figure()
+    if show:
+        fig = pyplot.figure()
+    else:
+        if (png == False) and (pdf == False):
+            png = True
+        fig = mpl_fig()
+
+#    fig = pyplot.figure()
     ax1 = fig.add_axes([0.1, 0.1, 0.77, 0.1])
     ax2 = fig.add_axes([0.1, 0.2, 0.77, 0.7])
     ax3 = fig.add_axes([0.88, 0.2, 0.02, 0.7])
@@ -454,6 +506,7 @@ def plot_rli(myBeam, normalized=True, xcf=False):
     ax1.set_xlabel('Range Gate')
 
     rad_name = pydarn.radar.network().getRadarById(myBeam.stid).name
+    rad = pydarn.radar.network().getRadarById(myBeam.stid).code[0]
     if xcf:
         title = myBeam.time.strftime('%d %b, %Y %H:%M:%S UT') + ' ' + \
             'XCF ' + rad_name + ' Beam: ' + str(myBeam.bmnum)
@@ -462,7 +515,31 @@ def plot_rli(myBeam, normalized=True, xcf=False):
             'ACF ' + rad_name + ' Beam: ' + str(myBeam.bmnum)
     fig.suptitle(title, y=0.94)
 
-    fig.show()
+    #handle the outputs
+    if png:
+        if not show:
+            canvas = FigureCanvasAgg(fig)
+        if xcf:
+            fig.savefig('XCF_' +
+                        myBeam.time.strftime("%Y%m%d_%H%M%S_UT") +
+                        '_' + rad + '.png')
+        else:
+            fig.savefig('ACF_' +
+                        myBeam.time.strftime("%Y%m%d_%H%M%S_UT") +
+                        '_' + rad + '.png')
+    if pdf:
+        if not show:
+            canvas = FigureCanvasAgg(fig)
+        if xcf:
+            fig.savefig('XCF_' +
+                        myBeam.time.strftime("%Y%m%d_%H%M%S_UT") +
+                        '_' + rad + '.pdf')
+        else:
+            fig.savefig('ACF_' +
+                        myBeam.time.strftime("%Y%m%d_%H%M%S_UT") +
+                        '_' + rad + '.pdf')
+    if show:
+        fig.show()
 
 
 def nuft(a, tn, T):

--- a/pydarn/plotting/acfPlot.py
+++ b/pydarn/plotting/acfPlot.py
@@ -1,16 +1,16 @@
 # Copyright (C) 2012  VT SuperDARN Lab
 # Full license can be found in LICENSE.txt
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -42,10 +42,10 @@ def plot_acf(myBeam, gate, normalized=True, mark_blanked=True,
         * **gate**: (int) The range gate to plot data for.
         * **[normalized]**: (boolean) Specifies whether to normalize the
                             ACF/XCF data by the lag-zero power.
-        * **[mark_blanked]**: (boolean) Specifies whether magnitude and 
-                              phase should be plotted instead of real and 
+        * **[mark_blanked]**: (boolean) Specifies whether magnitude and
+                              phase should be plotted instead of real and
                               imaginary.
-        * **[xcf]**: (boolean) Specifies wheather to plot XCF data or not 
+        * **[xcf]**: (boolean) Specifies whether to plot XCF data or not
         * **[panel]**: (int) from 0 to 3 specifies which data to plot of
                        ACF/XCF, ACF/XCF amplitude, ACF/XCF phase, or
                        power spectrum, respectively. Default is panel=0.

--- a/pydarn/plotting/acfPlot.py
+++ b/pydarn/plotting/acfPlot.py
@@ -30,7 +30,7 @@
   * :func:`pydarn.plotting.acfPlot.nuft`
 """
 
-def plot_acf(myBeam, gate, show_blanked=True, xcf=False, panel=0, ax=None):
+def plot_acf(myBeam, gate, mark_blanked=True, xcf=False, panel=0, ax=None):
 
     """Plot the ACF/XCF for a specified beamData object at a
        specified range gate
@@ -38,7 +38,7 @@ def plot_acf(myBeam, gate, show_blanked=True, xcf=False, panel=0, ax=None):
     **Args**:
         * **myBeam** : a beamData object from pydarn.sdio.radDataTypes
         * **gate**: (int) The range gate to plot data for.
-        * **[show_blanked]**: (boolean) Specifies whether magnitude and 
+        * **[mark_blanked]**: (boolean) Specifies whether magnitude and 
                               phase should be plotted instead of real and 
                               imaginary.
         * **[xcf]**: (boolean) Specifies wheather to plot XCF data or not 
@@ -138,7 +138,7 @@ def plot_acf(myBeam, gate, show_blanked=True, xcf=False, panel=0, ax=None):
         ax1.set_title(title1)
    
     if (ax1 is not None):
-        if ((blanked) and (show_blanked)):
+        if ((blanked) and (mark_blanked)):
             inds = np.where(tx == 1)[0]
             if len(inds):
                 for ind in inds:
@@ -161,7 +161,7 @@ def plot_acf(myBeam, gate, show_blanked=True, xcf=False, panel=0, ax=None):
         ax2 = ax
 
     if (ax2 is not None):
-        if ((blanked) and (show_blanked)):
+        if ((blanked) and (mark_blanked)):
             inds = np.where(tx == 1)[0]
             if len(inds):
                 for ind in inds:
@@ -181,7 +181,7 @@ def plot_acf(myBeam, gate, show_blanked=True, xcf=False, panel=0, ax=None):
         ax3 = ax
 
     if (ax3 is not None):
-        if ((blanked) and (show_blanked)):
+        if ((blanked) and (mark_blanked)):
             inds = np.where(tx == 1)[0]
             if len(inds):
                 for ind in inds:
@@ -456,8 +456,8 @@ if __name__ == "__main__":
     print "...First test default options, at range gate 31, you should see ground scatter and lags marked that are blanked by Tx blanking..."
     pydarn.plotting.acfPlot.plot_acf(myBeam,31)
 
-    print "...Next, with 'show_blanked=False', blanking marking turned off "
-    pydarn.plotting.acfPlot.plot_acf(myBeam,31,show_blanked=False)
+    print "...Next, with 'mark_blanked=False', blanking marking turned off "
+    pydarn.plotting.acfPlot.plot_acf(myBeam,31,mark_blanked=False)
 
     print "...Next, with 'xcf=True', plotting xcf data"
     pydarn.plotting.acfPlot.plot_acf(myBeam,31,xcf=True)

--- a/pydarn/plotting/acfPlot.py
+++ b/pydarn/plotting/acfPlot.py
@@ -30,10 +30,11 @@
   * :func:`pydarn.plotting.acfPlot.nuft`
 """
 
-def plot_acf(myBeam, gate, mark_blanked=True, xcf=False, panel=0, ax=None):
 
-    """Plot the ACF/XCF for a specified beamData object at a
-       specified range gate
+def plot_acf(myBeam, gate, mark_blanked=True, xcf=False, panel=0, ax=None):
+    """
+    Plot the ACF/XCF for a specified beamData object at a
+    specified range gate
 
     **Args**:
         * **myBeam** : a beamData object from pydarn.sdio.radDataTypes
@@ -64,99 +65,103 @@ def plot_acf(myBeam, gate, mark_blanked=True, xcf=False, panel=0, ax=None):
     from matplotlib import pyplot
     import numpy as np
     import pydarn
-                 
-    number_lags = myBeam.prm.mplgs
-    lags = list(set([x[1]-x[0] for x in myBeam.prm.ltab]))
+
+    lags = list(set([x[1] - x[0] for x in myBeam.prm.ltab]))
     ltab = myBeam.prm.ltab
-    smsep = myBeam.prm.smsep
     tau = myBeam.prm.mpinc
     tfr = myBeam.prm.lagfr
     tp = myBeam.prm.txpl
-    nrang = myBeam.prm.nrang
     nave = myBeam.prm.nave
     mplgs = myBeam.prm.mplgs
     noise = np.array(myBeam.prm.noisesearch)
     power = np.array(myBeam.rawacf.pwr0)
-    fluct = 1/np.sqrt(nave)*(1+1/(power[gate]/noise))
+    fluct = 1 / np.sqrt(nave) * (1 + 1 / (power[gate] / noise))
 
-    #Grab the appropriate data for plotting
+    # Grab the appropriate data for plotting
     if ((xcf) and (myBeam.prm.xcf == 0)):
         print "No interferometer data available."
         return
     elif ((xcf) and (myBeam.prm.xcf == 1)):
-        re = np.array([x[0]/power[gate] for x in myBeam.rawacf.xcfd[gate]]) 
-        im = np.array([x[1]/power[gate] for x in myBeam.rawacf.xcfd[gate]])
+        re = np.array([x[0] / power[gate] for x in
+                       myBeam.rawacf.xcfd[gate]])
+        im = np.array([x[1] / power[gate] for x in
+                       myBeam.rawacf.xcfd[gate]])
     else:
-        re = np.array([x[0]/power[gate] for x in myBeam.rawacf.acfd[gate]])
-        im = np.array([x[1]/power[gate] for x in myBeam.rawacf.acfd[gate]])
+        re = np.array([x[0] / power[gate] for x in
+                       myBeam.rawacf.acfd[gate]])
+        im = np.array([x[1] / power[gate] for x in
+                       myBeam.rawacf.acfd[gate]])
 
-    # determine which lags are blanked by Tx pulses
-    blanked = calc_blanked(ltab,tp,tau,tfr,gate)
+    # Determine which lags are blanked by Tx pulses
+    blanked = calc_blanked(ltab, tp, tau, tfr, gate)
     tx = np.zeros(mplgs)
-    for l,lag in enumerate(lags):
+    for l, lag in enumerate(lags):
         if len(blanked[lag]):
             tx[l] = 1
         else:
-            tx[l] = 0 
+            tx[l] = 0
 
-    # Take the fourier transform of the complex ACF to 
+    # Take the fourier transform of the complex ACF to
     # get the power spectrum
-    temp = nuft(re+1j*im,np.array(lags),lags[-1])
+    temp = nuft(re + 1j * im, np.array(lags), lags[-1])
     acfFFT = []
-    acfFFT.extend(temp[len(temp)/2+1:])
-    acfFFT.extend(temp[0:len(temp)/2+1])
-    freq_scale_factor = 1/(lags[-1]*myBeam.prm.mpinc*10.0**-6)/(myBeam.prm.tfreq*1000.)/2.*(3.*10**8)
-    vels = freq_scale_factor*(np.array(range(len(acfFFT)))-len(acfFFT)/2)  
+    acfFFT.extend(temp[len(temp) / 2 + 1:])
+    acfFFT.extend(temp[0:len(temp) / 2 + 1])
+    freq_scale_factor = 1 / (lags[-1] * myBeam.prm.mpinc * 10.0 ** -6) \
+        / (myBeam.prm.tfreq * 1000.) / 2. * (3. * 10 ** 8)
+    vels = freq_scale_factor * (np.array(range(len(acfFFT))) -
+                                len(acfFFT) / 2)
 
     # Calculate the amplitude and phase of the complex ACF/XCF
-    amplitude = np.sqrt(re**2 + im**2)
-    phase = np.arctan2(im,re)
+    amplitude = np.sqrt(re ** 2 + im ** 2)
+    phase = np.arctan2(im, re)
 
-    #Calculate bounds for plotting
+    # Calculate bounds for plotting
     lag_numbers = []
     for lag in lags:
-        temp = [lag-0.5, lag+0.5]
+        temp = [lag - 0.5, lag + 0.5]
         lag_numbers.extend(temp)
 
     if ax is None:
-        fig=pyplot.figure()
-        ax1=fig.add_axes([0.1,0.55,0.35,0.35])
-        ax2=fig.add_axes([0.1,0.1,0.35,0.35])
-        ax3=fig.add_axes([0.5,0.1,0.35,0.35])
-        ax4=fig.add_axes([0.5,0.55,0.35,0.35])
+        fig = pyplot.figure()
+        ax1 = fig.add_axes([0.1, 0.55, 0.35, 0.35])
+        ax2 = fig.add_axes([0.1, 0.1, 0.35, 0.35])
+        ax3 = fig.add_axes([0.5, 0.1, 0.35, 0.35])
+        ax4 = fig.add_axes([0.5, 0.55, 0.35, 0.35])
     else:
-        ax1=None
-        ax2=None
-        ax3=None
-        ax4=None
+        ax1 = None
+        ax2 = None
+        ax3 = None
+        ax4 = None
 
-    #Now plot the ACF/XCF panel as necessary
+    # Now plot the ACF/XCF panel as necessary
     if (ax is not None) and (panel == 0):
         ax1 = ax
     elif (ax1 is not None):
         title1 = myBeam.time.strftime('%d %b, %Y %H:%M:%S UT')
         ax1.set_title(title1)
-   
+
     if (ax1 is not None):
         if ((blanked) and (mark_blanked)):
             inds = np.where(tx == 1)[0]
             if len(inds):
                 for ind in inds:
-                    ax1.plot(lags[ind],re[ind],marker='x',color='red',mew=3,ms=8,zorder=10)
-                    ax1.plot(lags[ind],im[ind],marker='x',color='red',mew=3,ms=8,zorder=10)
-    
-        ax1.plot(lags,re,marker='o',color='blue',lw=2)
-        ax1.plot(lags,im,marker='o',color='green',lw=2)
-        ax1.plot([lags[0],lags[-1]+1],[0,0],'k--',lw=2)
+                    ax1.plot(lags[ind], re[ind], marker='x',
+                             color='red', mew=3, ms=8, zorder=10)
+                    ax1.plot(lags[ind], im[ind], marker='x',
+                             color='red', mew=3, ms=8, zorder=10)
 
-        ax1.set_xlim([-0.5,lag_numbers[-1]])
-        ax1.set_xlabel('Lag Number') 
-        ax1.set_ylabel('ACF') 
-        ax1.set_ylim([-1.5,1.5])
-        ax1.set_yticks(np.linspace(-1,1,num=5))
+        ax1.plot(lags, re, marker='o', color='blue', lw=2)
+        ax1.plot(lags, im, marker='o', color='green', lw=2)
+        ax1.plot([lags[0], lags[-1] + 1], [0, 0], 'k--', lw=2)
 
+        ax1.set_xlim([-0.5, lag_numbers[-1]])
+        ax1.set_xlabel('Lag Number')
+        ax1.set_ylabel('ACF')
+        ax1.set_ylim([-1.5, 1.5])
+        ax1.set_yticks(np.linspace(-1, 1, num=5))
 
-    #Now plot the ACF/XCF amplitude panel as necessary
+    # Now plot the ACF/XCF amplitude panel as necessary
     if ((ax is not None) and (panel == 1)):
         ax2 = ax
 
@@ -165,18 +170,21 @@ def plot_acf(myBeam, gate, mark_blanked=True, xcf=False, panel=0, ax=None):
             inds = np.where(tx == 1)[0]
             if len(inds):
                 for ind in inds:
-                    ax2.plot(lags[ind],amplitude[ind],marker='x',color='red',mew=3,ms=8,zorder=10)  
+                    ax2.plot(lags[ind], amplitude[ind], marker='x',
+                             color='red', mew=3, ms=8, zorder=10)
 
-        ax2.plot(lags,amplitude,marker='o',color='black',lw=2,zorder=1)
-        ax2.plot([lags[0],lags[-1]+1],[fluct,fluct],'b--',lw=2,zorder=1)
-  
-        ax2.set_xlim([-0.5,lag_numbers[-1]])
-        ax2.set_xlabel('Lag Number') 
-        ax2.set_ylabel('Lag Power')   
-        ax2.set_ylim([0,1.05*np.max(amplitude)])
-        ax2.set_yticks(np.linspace(0.2,1.2,num=6))
+        ax2.plot(lags, amplitude, marker='o', color='black', lw=2,
+                 zorder=1)
+        ax2.plot([lags[0], lags[-1] + 1], [fluct, fluct], 'b--', lw=2,
+                 zorder=1)
 
-    #Now plot the ACF/XCF phase panel as necessary
+        ax2.set_xlim([-0.5, lag_numbers[-1]])
+        ax2.set_xlabel('Lag Number')
+        ax2.set_ylabel('Lag Power')
+        ax2.set_ylim([0, 1.05 * np.max(amplitude)])
+        ax2.set_yticks(np.linspace(0.2, 1.2, num=6))
+
+    # Now plot the ACF/XCF phase panel as necessary
     if ((ax is not None) and (panel == 2)):
         ax3 = ax
 
@@ -185,32 +193,32 @@ def plot_acf(myBeam, gate, mark_blanked=True, xcf=False, panel=0, ax=None):
             inds = np.where(tx == 1)[0]
             if len(inds):
                 for ind in inds:
-                    ax3.plot(lags[ind],phase[ind],marker='x', \
-                             color='black',mew=3,ms=8,zorder=10)
-    
-        ax3.plot(lags,phase,marker='o',color='red',lw=2)
-        ax3.plot([lags[0],lags[-1]+1],[0,0],'k--',lw=2)
-  
-        ax3.set_xlim([-0.50,lag_numbers[-1]])
-        ax3.set_xlabel('Lag Number')  
+                    ax3.plot(lags[ind], phase[ind], marker='x',
+                             color='black', mew=3, ms=8, zorder=10)
+
+        ax3.plot(lags, phase, marker='o', color='red', lw=2)
+        ax3.plot([lags[0], lags[-1] + 1], [0, 0], 'k--', lw=2)
+
+        ax3.set_xlim([-0.50, lag_numbers[-1]])
+        ax3.set_xlabel('Lag Number')
         ax3.set_ylabel('Phase')
-        ax3.set_ylim([-np.pi-0.5,np.pi+0.5])
-        ax3.set_yticks(np.linspace(-3,3,num=7))
+        ax3.set_ylim([-np.pi - 0.5, np.pi + 0.5])
+        ax3.set_yticks(np.linspace(-3, 3, num=7))
         if ax is None:
             ax3.yaxis.set_ticks_position('right')
             ax3.yaxis.set_label_position('right')
 
-    #Now plot the power spectrum panel as necessary
+    # Now plot the power spectrum panel as necessary
     if ((ax is not None) and (panel == 3)):
         ax4 = ax
     elif (ax4 is not None):
-        title2 = pydarn.radar.network().getRadarById(myBeam.stid).name+\
-                 ' Beam: '+str(myBeam.bmnum)+' Gate: '+str(gate)
+        title2 = pydarn.radar.network().getRadarById(myBeam.stid).name \
+            + ' Beam: ' + str(myBeam.bmnum) + ' Gate: ' + str(gate)
         ax4.set_title(title2)
 
     if (ax4 is not None):
-        ax4.plot(vels,np.abs(acfFFT),marker='o',lw=2)
-        ax4.set_xlabel('Velocity (m/s)')  
+        ax4.plot(vels, np.abs(acfFFT), marker='o', lw=2)
+        ax4.set_xlabel('Velocity (m/s)')
         ax4.set_ylabel('Spectral Power (arb)')
         if ax is None:
             ax4.yaxis.set_ticks_position('right')
@@ -218,15 +226,16 @@ def plot_acf(myBeam, gate, mark_blanked=True, xcf=False, panel=0, ax=None):
 
     if ax is None:
         fig.show()
-  
 
-def calc_blanked(ltab,tp,tau,tfr,gate):
 
-    """Function that calculates the lags that are affected by Tx pulse 
-       receiver blanking.
+def calc_blanked(ltab, tp, tau, tfr, gate):
+    """
+    Function that calculates the lags that are affected by Tx pulse
+    receiver blanking.
 
     **Args**:
-        * **ltab** : (list) The received lag table for the Tx-ed pulse sequence.
+        * **ltab** : (list) The received lag table for the Tx-ed pulse
+                            sequence.
         * **tp**: (int) The Tx pulse length in microseconds.
         * **tau**: (int) The lag time in microseconds.
         * **tfr**: (int) The time to first range gate in microseconds.
@@ -250,40 +259,38 @@ def calc_blanked(ltab,tp,tau,tfr,gate):
         Written by ASR 20141230
     """
 
-    import numpy as np
-
-    #Calculate the lags and the pulse table
+    # Calculate the lags and the pulse table
     lags = []
     ptab = []
     for pair in ltab:
-        lags.append(pair[1]-pair[0])
+        lags.append(pair[1] - pair[0])
         ptab.extend(pair)
-    lags=list(set(lags))
-    ptab=list(set(ptab))
-    lags.sort()  
+    lags = list(set(lags))
+    ptab = list(set(ptab))
+    lags.sort()
     ptab.sort()
 
-    txs_in_lag={}
+    txs_in_lag = {}
     for lag in lags:
-        txs_in_lag[lag]=[]
+        txs_in_lag[lag] = []
 
-    #number of ranges per tau
-    tp_in_tau = tau/tp
+    # Number of ranges per tau
+    tp_in_tau = tau / tp
 
-    #determine which range gates correspond to blanked samples
-    tx_times=[p*tp_in_tau for p in ptab]
-    blanked_samples=[]
+    # Determine which range gates correspond to blanked samples
+    tx_times = [p * tp_in_tau for p in ptab]
+    blanked_samples = []
     for tx in tx_times:
-        blanked_samples.extend([tx, tx+1])
+        blanked_samples.extend([tx, tx + 1])
 
     for lag in lags:
         for pair in ltab:
             if (pair[1] - pair[0] == lag):
-                #which samples were used to generate the acf
-                S1=tp_in_tau*pair[0]+gate + 1.*tfr/(tp)
-                S2=tp_in_tau*pair[1]+gate + 1.*tfr/(tp)
-                br=[]
-                #check to see if the samples are blanked or not
+                # Which samples were used to generate the acf
+                S1 = tp_in_tau * pair[0] + gate + 1. * tfr / (tp)
+                S2 = tp_in_tau * pair[1] + gate + 1. * tfr / (tp)
+                br = []
+                # Check to see if the samples are blanked or not
                 if S1 in blanked_samples:
                     br.append(S1)
                 if S2 in blanked_samples:
@@ -293,16 +300,15 @@ def calc_blanked(ltab,tp,tau,tfr,gate):
     return txs_in_lag
 
 
-
-
 def plot_rli(myBeam, xcf=False):
-
-    """This function plots a range-lag-intensity plot of ACF/XCF data for
-       an input beamData object.
+    """
+    This function plots a range-lag-intensity plot of ACF/XCF data
+    for an input beamData object.
 
     **Args**:
         * **myBeam** : A beamData object from pydarn.sdio.radDataTypes.
-        * **[xcf]**: (boolean) Specifies wheather to plot XCF data or not.
+        * **[xcf]**: (boolean) Specifies wheather to plot XCF data or
+                               not.
 
     **Returns**:
         Nothing.
@@ -324,92 +330,98 @@ def plot_rli(myBeam, xcf=False):
     import matplotlib as mpl
     import matplotlib.cm as cmx
 
-    #Get parameters
-    number_lags = myBeam.prm.mplgs
-    lags = list(set([x[1]-x[0] for x in myBeam.prm.ltab]))
-    range_gates = np.linspace(0.5,myBeam.prm.nrang+0.5,num=myBeam.prm.nrang+1)
-    power=np.array(myBeam.rawacf.pwr0)
-    noise=np.array(myBeam.prm.noisesearch)
+    # Get parameters
+    lags = list(set([x[1] - x[0] for x in myBeam.prm.ltab]))
+    range_gates = np.linspace(0.5, myBeam.prm.nrang + 0.5,
+                              num=myBeam.prm.nrang + 1)
+    power = np.array(myBeam.rawacf.pwr0)
+    noise = np.array(myBeam.prm.noisesearch)
 
-    #Make the figure and axes
-    fig=pyplot.figure()
-    ax1=fig.add_axes([0.1,0.1,0.77,0.1])
-    ax2=fig.add_axes([0.1,0.2,0.77,0.7])
-    ax3=fig.add_axes([0.88,0.2,0.02,0.7])
+    # Make the figure and axes
+    fig = pyplot.figure()
+    ax1 = fig.add_axes([0.1, 0.1, 0.77, 0.1])
+    ax2 = fig.add_axes([0.1, 0.2, 0.77, 0.7])
+    ax3 = fig.add_axes([0.88, 0.2, 0.02, 0.7])
 
-    #Plot the SNR
-    ax1.plot(range(1,myBeam.prm.nrang+1),10*np.log10(power/noise),lw=5)
+    # Plot the SNR
+    ax1.plot(range(1, myBeam.prm.nrang + 1), 10 *
+             np.log10(power / noise), lw=5)
 
-    #Calculate bounds for plotting
+    # Calculate bounds for plotting
     lag_numbers = []
     for lag in lags:
-        temp = [lag-0.5, lag+0.5]
+        temp = [lag - 0.5, lag + 0.5]
         lag_numbers.extend(temp)
 
-    #generate a scalar colormapping to map data to cmap
-    cl=[-1,1]
-    cmap='jet'
+    # Generate a scalar colormapping to map data to cmap
+    cl = [-1, 1]
+    cmap = 'jet'
     cNorm = colors.Normalize(vmin=cl[0], vmax=cl[1])
     scalarMap = cmx.ScalarMappable(norm=cNorm, cmap=cmap)
 
-    #Now plot SCR data  
+    # Now plot SCR data
     for r in range(myBeam.prm.nrang):
 
-        #Grab the appropriate data for plotting
+        # Grab the appropriate data for plotting
         if ((xcf) and (myBeam.prm.xcf == 0)):
             print "No interferometer data available."
             return
         elif ((xcf) and (myBeam.prm.xcf == 1)):
-            re = np.array([x[0]/power[r] for x in myBeam.rawacf.xcfd[r]]) 
-            im = np.array([x[1]/power[r] for x in myBeam.rawacf.xcfd[r]])
+            re = np.array([x[0] / power[r] for x in
+                           myBeam.rawacf.xcfd[r]])
+            im = np.array([x[1] / power[r] for x in
+                           myBeam.rawacf.xcfd[r]])
         else:
-            re = np.array([x[0]/power[r] for x in myBeam.rawacf.acfd[r]])
-            im = np.array([x[1]/power[r] for x in myBeam.rawacf.acfd[r]])
+            re = np.array([x[0] / power[r] for x in
+                           myBeam.rawacf.acfd[r]])
+            im = np.array([x[1] / power[r] for x in
+                           myBeam.rawacf.acfd[r]])
 
-      #Index needed for plotting but not incrementing on missing lags
-        i=0
-        for l in range(lags[-1]+1):
-            #Make coordinates for:
-            #Real and
-            x1 = np.array([r+0.5,r+0.5,r+1.0,r+1.0])
-            #Imaginary compenents of ACF/XCF
-            x2 = np.array([r+1.0,r+1.0,r+1.5,r+1.5])
-            y = np.array([l-0.5,l+0.5,l+0.5,l-0.5])
+        # Index needed for plotting but not incrementing on missing lags
+        i = 0
+        for l in range(lags[-1] + 1):
+            # Make coordinates for:
+            # Real and
+            x1 = np.array([r + 0.5, r + 0.5, r + 1.0, r + 1.0])
+            # Imaginary compenents of ACF/XCF
+            x2 = np.array([r + 1.0, r + 1.0, r + 1.5, r + 1.5])
+            y = np.array([l - 0.5, l + 0.5, l + 0.5, l - 0.5])
 
-            #If the lag isn't a "missing" lag plot the data, else plot a black square.
+            # If the lag isn't a "missing" lag plot the data, else plot
+            # a black square.
             if (l in lags):
-                ax2.fill(x1,y,color=scalarMap.to_rgba(re[i]))
-                ax2.fill(x2,y,color=scalarMap.to_rgba(im[i]))
-                i+=1
+                ax2.fill(x1, y, color=scalarMap.to_rgba(re[i]))
+                ax2.fill(x2, y, color=scalarMap.to_rgba(im[i]))
+                i += 1
             else:
-                ax2.fill(x1,y,color='black')
-                ax2.fill(x2,y,color='black')
+                ax2.fill(x1, y, color='black')
+                ax2.fill(x2, y, color='black')
 
-    #Add the colorbar and label it    
-    cbar = mpl.colorbar.ColorbarBase(ax3,norm=cNorm,cmap=cmap)
+    # Add the colorbar and label it
+    cbar = mpl.colorbar.ColorbarBase(ax3, norm=cNorm, cmap=cmap)
     cbar.set_label('Amplitude')
 
-    #Set plot axis labels
-    ax2.set_ylim([-0.5,lag_numbers[-1]])
-    ax2.set_yticks(np.linspace(0,lags[-1],num=lags[-1]+1))
-    ax2.set_xlim([range_gates[0],range_gates[-1]])
-    ax2.set_xticklabels([],visible=False)
+    # Set plot axis labels
+    ax2.set_ylim([-0.5, lag_numbers[-1]])
+    ax2.set_yticks(np.linspace(0, lags[-1], num=lags[-1] + 1))
+    ax2.set_xlim([range_gates[0], range_gates[-1]])
+    ax2.set_xticklabels([], visible=False)
     ax2.set_ylabel('Lag Number')
 
-    #Set pwr0 plot axis labels
-    ax1.set_xlim([range_gates[0],range_gates[-1]])
-    ax1.set_ylim([0,40])
-    ax1.set_yticks(np.linspace(0,30,num=4))
+    # Set pwr0 plot axis labels
+    ax1.set_xlim([range_gates[0], range_gates[-1]])
+    ax1.set_ylim([0, 40])
+    ax1.set_yticks(np.linspace(0, 30, num=4))
     ax1.set_ylabel(r'pwr$_{0}$''\n(dB)')
     ax1.set_xlabel('Range Gate')
 
     fig.show()
 
 
-
-
-def nuft(a,tn,T):
-    """A function to calculate the non-uniformly sampled discrete Fourier transform.
+def nuft(a, tn, T):
+    """
+    A function to calculate the non-uniformly sampled discrete
+    Fourier transform.
 
     **Args**:
         * **a** : (np.array) The input array to be transformed.
@@ -423,23 +435,22 @@ def nuft(a,tn,T):
     """
 
     import numpy as np
-    T=float(T)
-    ft=np.zeros((len(a),),np.complex)
+
+    T = float(T)
+    ft = np.zeros((len(a),), np.complex)
     for m in range(len(a)):
-        ft[m] = np.sum(a*np.exp(-1j*2*np.pi/T*m*tn))
+        ft[m] = np.sum(a * np.exp(-1j * 2 * np.pi / T * m * tn))
 
     return ft
 
 
-
 if __name__ == "__main__":
-
     import pydarn
     from datetime import datetime
     from matplotlib import pyplot
 
     print "First we need to fetch an rawacf file and read a beam record..."
-    myPtr = pydarn.sdio.radDataOpen(datetime(2012,5,21),'sas', eTime=datetime(2012,5,21,2),fileType='rawacf')
+    myPtr = pydarn.sdio.radDataOpen(datetime(2012, 5, 21), 'sas', eTime=datetime(2012, 5, 21, 2), fileType='rawacf')
     myBeam = myPtr.readRec()
 
     print "Testing the plot_rli method and it's options...."
@@ -447,25 +458,25 @@ if __name__ == "__main__":
     pydarn.plotting.acfPlot.plot_rli(myBeam)
 
     print "...Next test with 'xcf=True'..."
-    pydarn.plotting.acfPlot.plot_rli(myBeam,xcf=True)
+    pydarn.plotting.acfPlot.plot_rli(myBeam, xcf=True)
 
     print "Close the figures to proceed with testing..."
     pyplot.show()
 
     print "Testing the plot_acf method and it's options...."
     print "...First test default options, at range gate 31, you should see ground scatter and lags marked that are blanked by Tx blanking..."
-    pydarn.plotting.acfPlot.plot_acf(myBeam,31)
+    pydarn.plotting.acfPlot.plot_acf(myBeam, 31)
 
     print "...Next, with 'mark_blanked=False', blanking marking turned off "
-    pydarn.plotting.acfPlot.plot_acf(myBeam,31,mark_blanked=False)
+    pydarn.plotting.acfPlot.plot_acf(myBeam, 31, mark_blanked=False)
 
     print "...Next, with 'xcf=True', plotting xcf data"
-    pydarn.plotting.acfPlot.plot_acf(myBeam,31,xcf=True)
+    pydarn.plotting.acfPlot.plot_acf(myBeam, 31, xcf=True)
 
     fig = pyplot.figure()
-    ax = fig.add_axes([0.1,0.1,0.8,0.8])
+    ax = fig.add_axes([0.1, 0.1, 0.8, 0.8])
     print "...Next, plotting to our own axis object, 'ax=ax'"
-    pydarn.plotting.acfPlot.plot_acf(myBeam,31,ax=ax)
+    pydarn.plotting.acfPlot.plot_acf(myBeam, 31, ax=ax)
 
     pyplot.show()
 

--- a/pydarn/plotting/acfPlot.py
+++ b/pydarn/plotting/acfPlot.py
@@ -329,6 +329,7 @@ def plot_rli(myBeam, xcf=False):
     from matplotlib import colors
     import matplotlib as mpl
     import matplotlib.cm as cmx
+    import pydarn
 
     # Get parameters
     lags = list(set([x[1] - x[0] for x in myBeam.prm.ltab]))
@@ -414,6 +415,16 @@ def plot_rli(myBeam, xcf=False):
     ax1.set_yticks(np.linspace(0, 30, num=4))
     ax1.set_ylabel(r'pwr$_{0}$''\n(dB)')
     ax1.set_xlabel('Range Gate')
+
+    rad_name = pydarn.radar.network().getRadarById(myBeam.stid).name
+    if xcf:
+        title = myBeam.time.strftime('%d %b, %Y %H:%M:%S UT') + ' ' + \
+            'XCF ' + rad_name + ' Beam: ' + str(myBeam.bmnum)
+    else:
+        title = myBeam.time.strftime('%d %b, %Y %H:%M:%S UT') + ' ' + \
+            'ACF ' +rad_name + ' Beam: ' + str(myBeam.bmnum)
+
+    ax2.set_title(title)
 
     fig.show()
 

--- a/pydarn/plotting/acfPlot.py
+++ b/pydarn/plotting/acfPlot.py
@@ -27,10 +27,10 @@
   * :func:`pydarn.plotting.acfPlot.plot_acf`
   * :func:`pydarn.plotting.acfPlot.calc_blanked`
   * :func:`pydarn.plotting.acfPlot.plot_rli`
-  * :func:`pydarn.plotting.acfPlot.nufft`
+  * :func:`pydarn.plotting.acfPlot.nuft`
 """
 
-def plot_acf(myBeam, gate, blanked=True, xcf=False, panel=0, ax=None):
+def plot_acf(myBeam, gate, show_blanked=True, xcf=False, panel=0, ax=None):
 
     """Plot the ACF/XCF for a specified beamData object at a
        specified range gate
@@ -38,10 +38,10 @@ def plot_acf(myBeam, gate, blanked=True, xcf=False, panel=0, ax=None):
     **Args**:
         * **myBeam** : a beamData object from pydarn.sdio.radDataTypes
         * **gate**: (int) The range gate to plot data for.
-        * **[blanked]**: (boolean) Specifies whether magnitude and 
-                           phase should be plotted instead of real and 
-                           imaginary.
-        * **[xcf]**: (boolean) Specifies wheather to plot XCF data or not
+        * **[show_blanked]**: (boolean) Specifies whether magnitude and 
+                              phase should be plotted instead of real and 
+                              imaginary.
+        * **[xcf]**: (boolean) Specifies wheather to plot XCF data or not 
         * **[panel]**: (int) from 0 to 3 specifies which data to plot of
                        ACF/XCF, ACF/XCF amplitude, ACF/XCF phase, or
                        power spectrum, respectively.
@@ -61,176 +61,175 @@ def plot_acf(myBeam, gate, blanked=True, xcf=False, panel=0, ax=None):
         Written by ASR 20141230
     """
 
-  from matplotlib import pyplot
-  import numpy as np
-  import pydarn
+    from matplotlib import pyplot
+    import numpy as np
+    import pydarn
                  
-  number_lags = myBeam.prm.mplgs
-  lags = list(set([x[1]-x[0] for x in myBeam.prm.ltab]))
-  ltab = myBeam.prm.ltab
-  smsep = myBeam.prm.smsep
-  tau = myBeam.prm.mpinc
-  tfr = myBeam.prm.lagfr
-  tp = myBeam.prm.txpl
-  nrang = myBeam.prm.nrang
-  nave = myBeam.prm.nave
-  mplgs = myBeam.prm.mplgs
-  noise = np.array(myBeam.prm.noisesearch)
-  power = np.array(myBeam.rawacf.pwr0)
-  fluct = 1/np.sqrt(nave)*(1+1/(power[gate]/noise))
+    number_lags = myBeam.prm.mplgs
+    lags = list(set([x[1]-x[0] for x in myBeam.prm.ltab]))
+    ltab = myBeam.prm.ltab
+    smsep = myBeam.prm.smsep
+    tau = myBeam.prm.mpinc
+    tfr = myBeam.prm.lagfr
+    tp = myBeam.prm.txpl
+    nrang = myBeam.prm.nrang
+    nave = myBeam.prm.nave
+    mplgs = myBeam.prm.mplgs
+    noise = np.array(myBeam.prm.noisesearch)
+    power = np.array(myBeam.rawacf.pwr0)
+    fluct = 1/np.sqrt(nave)*(1+1/(power[gate]/noise))
 
-  #Grab the appropriate data for plotting
-  if ((xcf) and (myBeam.prm.xcf == 0)):
-    print "No interferometer data available."
-    return
-  elif ((xcf) and (myBeam.prm.xcf == 1)):
-    re = np.array([x[0]/power[gate] for x in myBeam.rawacf.xcfd[gate]]) 
-    im = np.array([x[1]/power[gate] for x in myBeam.rawacf.xcfd[gate]])
-  else:
-    re = np.array([x[0]/power[gate] for x in myBeam.rawacf.acfd[gate]])
-    im = np.array([x[1]/power[gate] for x in myBeam.rawacf.acfd[gate]])
-
-  # determine which lags are blanked by Tx pulses
-  blanked = calc_blanked(ltab,tp,tau,tfr,gate)
-  tx = np.zeros(mplgs)
-  for l,lag in enumerate(lags):
-    if len(blanked[lag]):
-      tx[l] = 1
+    #Grab the appropriate data for plotting
+    if ((xcf) and (myBeam.prm.xcf == 0)):
+        print "No interferometer data available."
+        return
+    elif ((xcf) and (myBeam.prm.xcf == 1)):
+        re = np.array([x[0]/power[gate] for x in myBeam.rawacf.xcfd[gate]]) 
+        im = np.array([x[1]/power[gate] for x in myBeam.rawacf.xcfd[gate]])
     else:
-      tx[l] = 0 
+        re = np.array([x[0]/power[gate] for x in myBeam.rawacf.acfd[gate]])
+        im = np.array([x[1]/power[gate] for x in myBeam.rawacf.acfd[gate]])
 
-  # Take the fourier transform of the complex ACF to 
-  # get the power spectrum
-  temp = nufft(re+1j*im,np.array(lags),lags[-1])
-  acfFFT = []
-  acfFFT.extend(temp[len(temp)/2+1:])
-  acfFFT.extend(temp[0:len(temp)/2+1])
-  freq_scale_factor = 1/(lags[-1]*myBeam.prm.mpinc*10.0**-6)/(myBeam.prm.tfreq*1000.)/2.*(3.*10**8)
-  vels = freq_scale_factor*(np.array(range(len(acfFFT)))-len(acfFFT)/2)  
+    # determine which lags are blanked by Tx pulses
+    blanked = calc_blanked(ltab,tp,tau,tfr,gate)
+    tx = np.zeros(mplgs)
+    for l,lag in enumerate(lags):
+        if len(blanked[lag]):
+            tx[l] = 1
+        else:
+            tx[l] = 0 
 
-  # Calculate the amplitude and phase of the complex ACF/XCF
-  amplitude = np.sqrt(re**2 + im**2)
-  phase = np.arctan2(im,re)
+    # Take the fourier transform of the complex ACF to 
+    # get the power spectrum
+    temp = nuft(re+1j*im,np.array(lags),lags[-1])
+    acfFFT = []
+    acfFFT.extend(temp[len(temp)/2+1:])
+    acfFFT.extend(temp[0:len(temp)/2+1])
+    freq_scale_factor = 1/(lags[-1]*myBeam.prm.mpinc*10.0**-6)/(myBeam.prm.tfreq*1000.)/2.*(3.*10**8)
+    vels = freq_scale_factor*(np.array(range(len(acfFFT)))-len(acfFFT)/2)  
 
-  #Calculate bounds for plotting
-  lag_numbers = []
-  for lag in lags:
-    temp = [lag-0.5, lag+0.5]
-    lag_numbers.extend(temp)
+    # Calculate the amplitude and phase of the complex ACF/XCF
+    amplitude = np.sqrt(re**2 + im**2)
+    phase = np.arctan2(im,re)
 
-  if ax is None:
-    fig=pyplot.figure()
-    ax1=fig.add_axes([0.1,0.55,0.35,0.35])
-    ax2=fig.add_axes([0.1,0.1,0.35,0.35])
-    ax3=fig.add_axes([0.5,0.1,0.35,0.35])
-    ax4=fig.add_axes([0.5,0.55,0.35,0.35])
-  else:
-    ax1=None
-    ax2=None
-    ax3=None
-    ax4=None
+    #Calculate bounds for plotting
+    lag_numbers = []
+    for lag in lags:
+        temp = [lag-0.5, lag+0.5]
+        lag_numbers.extend(temp)
 
-  #Now plot the ACF/XCF panel as necessary
-  if (ax is not None) and (panel == 0):
-    ax1 = ax
-  elif (ax1 is not None):
-    title1 = myBeam.time.strftime('%d %b, %Y %H:%M:%S UT')
-    ax1.set_title(title1)
+    if ax is None:
+        fig=pyplot.figure()
+        ax1=fig.add_axes([0.1,0.55,0.35,0.35])
+        ax2=fig.add_axes([0.1,0.1,0.35,0.35])
+        ax3=fig.add_axes([0.5,0.1,0.35,0.35])
+        ax4=fig.add_axes([0.5,0.55,0.35,0.35])
+    else:
+        ax1=None
+        ax2=None
+        ax3=None
+        ax4=None
+
+    #Now plot the ACF/XCF panel as necessary
+    if (ax is not None) and (panel == 0):
+        ax1 = ax
+    elif (ax1 is not None):
+        title1 = myBeam.time.strftime('%d %b, %Y %H:%M:%S UT')
+        ax1.set_title(title1)
    
-  if (ax1 is not None):
-    if (blanked):
-      inds = np.where(tx == 1)[0]
-      print inds
-      if len(inds):
-        for ind in inds:
-          ax1.plot(lags[ind],re[ind],marker='x',color='red',mew=3,ms=8,zorder=10)  
-          ax1.plot(lags[ind],im[ind],marker='x',color='red',mew=3,ms=8,zorder=10)  
+    if (ax1 is not None):
+        if ((blanked) and (show_blanked)):
+            inds = np.where(tx == 1)[0]
+            if len(inds):
+                for ind in inds:
+                    ax1.plot(lags[ind],re[ind],marker='x',color='red',mew=3,ms=8,zorder=10)
+                    ax1.plot(lags[ind],im[ind],marker='x',color='red',mew=3,ms=8,zorder=10)
     
-    ax1.plot(lags,re,marker='o',color='blue',lw=2)
-    ax1.plot(lags,im,marker='o',color='green',lw=2)
-    ax1.plot([lags[0],lags[-1]+1],[0,0],'k--',lw=2)
+        ax1.plot(lags,re,marker='o',color='blue',lw=2)
+        ax1.plot(lags,im,marker='o',color='green',lw=2)
+        ax1.plot([lags[0],lags[-1]+1],[0,0],'k--',lw=2)
 
-    ax1.set_xlim([-0.5,lag_numbers[-1]])
-    ax1.set_xlabel('Lag Number') 
-    ax1.set_ylabel('ACF') 
-    ax1.set_ylim([-1.5,1.5])
-    ax1.set_yticks(np.linspace(-1,1,num=5))
+        ax1.set_xlim([-0.5,lag_numbers[-1]])
+        ax1.set_xlabel('Lag Number') 
+        ax1.set_ylabel('ACF') 
+        ax1.set_ylim([-1.5,1.5])
+        ax1.set_yticks(np.linspace(-1,1,num=5))
 
 
-  #Now plot the ACF/XCF amplitude panel as necessary
-  if ((ax is not None) and (panel == 1)):
-    ax2 = ax
+    #Now plot the ACF/XCF amplitude panel as necessary
+    if ((ax is not None) and (panel == 1)):
+        ax2 = ax
 
-  if (ax2 is not None):
-    if (blanked):
-      inds = np.where(tx == 1)[0]
-      if len(inds):
-        for ind in inds:
-          ax2.plot(lags[ind],amplitude[ind],marker='x',color='red',mew=3,ms=8,zorder=10)  
+    if (ax2 is not None):
+        if ((blanked) and (show_blanked)):
+            inds = np.where(tx == 1)[0]
+            if len(inds):
+                for ind in inds:
+                    ax2.plot(lags[ind],amplitude[ind],marker='x',color='red',mew=3,ms=8,zorder=10)  
 
-    ax2.plot(lags,amplitude,marker='o',color='black',lw=2,zorder=1)
-    ax2.plot([lags[0],lags[-1]+1],[fluct,fluct],'b--',lw=2,zorder=1)
+        ax2.plot(lags,amplitude,marker='o',color='black',lw=2,zorder=1)
+        ax2.plot([lags[0],lags[-1]+1],[fluct,fluct],'b--',lw=2,zorder=1)
   
-    ax2.set_xlim([-0.5,lag_numbers[-1]])
-    ax2.set_xlabel('Lag Number') 
-    ax2.set_ylabel('Lag Power')   
-    ax2.set_ylim([0,1.05*np.max(amplitude)])
-    ax2.set_yticks(np.linspace(0.2,1.2,num=6))
+        ax2.set_xlim([-0.5,lag_numbers[-1]])
+        ax2.set_xlabel('Lag Number') 
+        ax2.set_ylabel('Lag Power')   
+        ax2.set_ylim([0,1.05*np.max(amplitude)])
+        ax2.set_yticks(np.linspace(0.2,1.2,num=6))
 
-  #Now plot the ACF/XCF phase panel as necessary
-  if ((ax is not None) and (panel == 2)):
-    ax3 = ax
+    #Now plot the ACF/XCF phase panel as necessary
+    if ((ax is not None) and (panel == 2)):
+        ax3 = ax
 
-  if (ax3 is not None):
-    if (blanked):
-      inds = np.where(tx == 1)[0]
-      if len(inds):
-        for ind in inds:
-          ax3.plot(lags[ind],phase[ind],marker='x',color='black',mew=3,ms=8,zorder=10)
+    if (ax3 is not None):
+        if ((blanked) and (show_blanked)):
+            inds = np.where(tx == 1)[0]
+            if len(inds):
+                for ind in inds:
+                    ax3.plot(lags[ind],phase[ind],marker='x', \
+                             color='black',mew=3,ms=8,zorder=10)
     
-    ax3.plot(lags,phase,marker='o',color='red',lw=2)
-    ax3.plot([lags[0],lags[-1]+1],[0,0],'k--',lw=2)
+        ax3.plot(lags,phase,marker='o',color='red',lw=2)
+        ax3.plot([lags[0],lags[-1]+1],[0,0],'k--',lw=2)
   
-    ax3.set_xlim([-0.50,lag_numbers[-1]])
-    ax3.set_xlabel('Lag Number')  
-    ax3.set_ylabel('Phase')
-    ax3.set_ylim([-np.pi-0.5,np.pi+0.5])
-    ax3.set_yticks(np.linspace(-3,3,num=7))
+        ax3.set_xlim([-0.50,lag_numbers[-1]])
+        ax3.set_xlabel('Lag Number')  
+        ax3.set_ylabel('Phase')
+        ax3.set_ylim([-np.pi-0.5,np.pi+0.5])
+        ax3.set_yticks(np.linspace(-3,3,num=7))
+        if ax is None:
+            ax3.yaxis.set_ticks_position('right')
+            ax3.yaxis.set_label_position('right')
+
+    #Now plot the power spectrum panel as necessary
+    if ((ax is not None) and (panel == 3)):
+        ax4 = ax
+    elif (ax4 is not None):
+        title2 = pydarn.radar.network().getRadarById(myBeam.stid).name+\
+                 ' Beam: '+str(myBeam.bmnum)+' Gate: '+str(gate)
+        ax4.set_title(title2)
+
+    if (ax4 is not None):
+        ax4.plot(vels,np.abs(acfFFT),marker='o',lw=2)
+        ax4.set_xlabel('Velocity (m/s)')  
+        ax4.set_ylabel('Spectral Power (arb)')
+        if ax is None:
+            ax4.yaxis.set_ticks_position('right')
+            ax4.yaxis.set_label_position('right')
+
     if ax is None:
-      ax3.yaxis.set_ticks_position('right')
-      ax3.yaxis.set_label_position('right')
-
-  #Now plot the power spectrum panel as necessary
-  if ((ax is not None) and (panel == 3)):
-    ax4 = ax
-  elif (ax4 is not None):
-    title2 = pydarn.radar.network().getRadarById(myBeam.stid).name+\
-             ' Beam: '+str(myBeam.bmnum)+' Gate: '+str(gate)
-    ax4.set_title(title2)
-
-  if (ax4 is not None):
-    ax4.plot(vels,np.abs(acfFFT),marker='o',lw=2)
-    #ax4.set_xlim([-5000,5000])
-    ax4.set_xlabel('Velocity (m/s)')  
-    ax4.set_ylabel('Spectral Power (arb)')
-    if ax is None:
-      ax4.yaxis.set_ticks_position('right')
-      ax4.yaxis.set_label_position('right')
-
-  if ax is None:
-    fig.show()
+        fig.show()
   
 
 def calc_blanked(ltab,tp,tau,tfr,gate):
 
-    """Plot the ACF/XCF for a specified beamData object at a
-       specified range gate
+    """Function that calculates the lags that are affected by Tx pulse 
+       receiver blanking.
 
     **Args**:
-        * **ltab** : (list) 
-        * **tp**: (int) 
-        * **tau**: (int) 
-        * **tfr**: (int) 
+        * **ltab** : (list) The received lag table for the Tx-ed pulse sequence.
+        * **tp**: (int) The Tx pulse length in microseconds.
+        * **tau**: (int) The lag time in microseconds.
+        * **tfr**: (int) The time to first range gate in microseconds.
         * **gate**: (int) The range gate to plot data for.
 
     **Returns**:
@@ -242,141 +241,231 @@ def calc_blanked(ltab,tp,tau,tfr,gate):
             myPtr = pydarn.sdio.radDataOpen(datetime(2012,5,21), \
                                           'kap',fileType='rawacf')
             myBeam = myPtr.readRec()
-            pydarn.plotting.acfPlot.plot_acf(myBeam,24)
+            ltab = myBeam.prm.ltab
+            tau = myBeam.prm.mpinc
+            tfr = myBeam.prm.lagfr
+            tp = myBeam.prm.txpl
+            pydarn.plotting.acfPlot.calc_blanked(ltab,tp,tau,tfr,24)
 
         Written by ASR 20141230
     """
 
-  import numpy as np
+    import numpy as np
 
-  #Calculate the lags and the pulse table
-  lags = []
-  ptab = []
-  for pair in ltab:
-    lags.append(pair[1]-pair[0])
-    ptab.extend(pair)
-  lags=list(set(lags))
-  ptab=list(set(ptab))
-  lags.sort()  
-  ptab.sort()
-
-  txs_in_lag={}
-  for lag in lags:
-    txs_in_lag[lag]=[]
-
-  #number of ranges per tau
-  tp_in_tau = tau/tp
-
-  #determine which range gates correspond to blanked samples
-  tx_times=[p*tp_in_tau for p in ptab]
-  blanked_samples=[]
-  for tx in tx_times:
-    blanked_samples.extend([tx, tx+1])
-
-  for lag in lags:
+    #Calculate the lags and the pulse table
+    lags = []
+    ptab = []
     for pair in ltab:
-      if (pair[1] - pair[0] == lag):
-        #which samples were used to generate the acf
-        S1=tp_in_tau*pair[0]+gate + 1.*tfr/(tp)
-        S2=tp_in_tau*pair[1]+gate + 1.*tfr/(tp)
-        br=[]
-        #check to see if the samples are blanked or not
-        if S1 in blanked_samples:
-          br.append(S1)
-        if S2 in blanked_samples:
-          br.append(S2)
-        txs_in_lag[lag].extend(br)
+        lags.append(pair[1]-pair[0])
+        ptab.extend(pair)
+    lags=list(set(lags))
+    ptab=list(set(ptab))
+    lags.sort()  
+    ptab.sort()
 
-  return txs_in_lag
+    txs_in_lag={}
+    for lag in lags:
+        txs_in_lag[lag]=[]
 
+    #number of ranges per tau
+    tp_in_tau = tau/tp
 
-def plot_rli(myBeam):
+    #determine which range gates correspond to blanked samples
+    tx_times=[p*tp_in_tau for p in ptab]
+    blanked_samples=[]
+    for tx in tx_times:
+        blanked_samples.extend([tx, tx+1])
 
-  #Plot a Range-Lag Intensity plot
+    for lag in lags:
+        for pair in ltab:
+            if (pair[1] - pair[0] == lag):
+                #which samples were used to generate the acf
+                S1=tp_in_tau*pair[0]+gate + 1.*tfr/(tp)
+                S2=tp_in_tau*pair[1]+gate + 1.*tfr/(tp)
+                br=[]
+                #check to see if the samples are blanked or not
+                if S1 in blanked_samples:
+                    br.append(S1)
+                if S2 in blanked_samples:
+                    br.append(S2)
+                txs_in_lag[lag].extend(br)
 
-  from matplotlib import pyplot
-  import numpy as np
-
-  from matplotlib import colors
-  import matplotlib as mpl
-  import matplotlib.cm as cmx
-
-                 
-  number_lags = myBeam.prm.mplgs
-  lags = list(set([x[1]-x[0] for x in myBeam.prm.ltab]))
-
-  lag_numbers = []
-  for lag in lags:
-    temp = [lag-0.5, lag+0.5]
-    lag_numbers.extend(temp)
-
-  range_gates = np.linspace(0.5,myBeam.prm.nrang+0.5,num=myBeam.prm.nrang+1)
-
-  power=np.array(myBeam.rawacf.pwr0)
-  noise=np.array(myBeam.prm.noisesearch)
-
-  fig=pyplot.figure()
-  ax1=fig.add_axes([0.1,0.1,0.77,0.1])
-  ax2=fig.add_axes([0.1,0.2,0.77,0.7])
-  ax3=fig.add_axes([0.88,0.2,0.02,0.7])
-
-  ax1.plot(range(1,myBeam.prm.nrang+1),10*np.log10(power/noise),lw=5)
-
-  #generate a scalar colormapping to map data to cmap
-  cl=[-1,1]
-  cmap='jet'
-  cNorm = colors.Normalize(vmin=cl[0], vmax=cl[1])
-  scalarMap = cmx.ScalarMappable(norm=cNorm, cmap=cmap)
-
-  #Now plot SCR data  
-  for r in range(myBeam.prm.nrang):
-    acfRe = [x[0]/power[r] for x in myBeam.rawacf.acfd[r]]
-    acfIm = [x[1]/power[r] for x in myBeam.rawacf.acfd[r]]
-
-    i=0
-    for l in range(lags[-1]+1):
-      x1 = np.array([r+0.5,r+0.5,r+1.0,r+1.0])
-      x2 = np.array([r+1.0,r+1.0,r+1.5,r+1.5])
-      y = np.array([l-0.5,l+0.5,l+0.5,l-0.5])
-
-      if (l in lags):
-        ax2.fill(x1,y,color=scalarMap.to_rgba(acfRe[i]))
-        ax2.fill(x2,y,color=scalarMap.to_rgba(acfIm[i]))
-        i+=1
-      else:
-        ax2.fill(x1,y,color='black')
-        ax2.fill(x2,y,color='black')
+    return txs_in_lag
 
 
-  #Add the colorbar and label it    
-  cbar = mpl.colorbar.ColorbarBase(ax3,norm=cNorm,cmap=cmap)
-  cbar.set_label('Amplitude')
 
-  #Set plot axis labels
-  ax2.set_ylim([-0.5,lag_numbers[-1]])
-  ax2.set_yticks(np.linspace(0,lags[-1],num=lags[-1]+1))
-  ax2.set_xlim([range_gates[0],range_gates[-1]])
-  ax2.set_xticklabels([],visible=False)
-  ax2.set_ylabel('Lag Number')
 
-  #Set pwr0 plot axis labels
-  ax1.set_xlim([range_gates[0],range_gates[-1]])
-  ax1.set_ylim([0,40])
-  ax1.set_yticks(np.linspace(0,30,num=4))
-  ax1.set_ylabel(r'pwr$_{0}$''\n(dB)')
-  ax1.set_xlabel('Range Gate')
+def plot_rli(myBeam, xcf=False):
 
-  fig.show()
-  
+    """This function plots a range-lag-intensity plot of ACF/XCF data for
+       an input beamData object.
 
-#NON UNIFORMLY SAMPLED DFT!
-def nufft(a,tn,T):
+    **Args**:
+        * **myBeam** : A beamData object from pydarn.sdio.radDataTypes.
+        * **[xcf]**: (boolean) Specifies wheather to plot XCF data or not.
 
-  import numpy as np
-  T=float(T)
-  fft=np.zeros((len(a),),np.complex)
-  for m in range(len(a)):
-    fft[m] = np.sum(a*np.exp(-1j*2*np.pi/T*m*tn))
+    **Returns**:
+        Nothing.
 
-  return fft
+    **Example**:
+        ::
+            from datetime import datetime
+            myPtr = pydarn.sdio.radDataOpen(datetime(2012,5,21), \
+                                          'kap',fileType='rawacf')
+            myBeam = myPtr.readRec()
+            pydarn.plotting.acfPlot.plot_rli(myBeam)
+
+        Written by ASR 20141230
+    """
+
+    from matplotlib import pyplot
+    import numpy as np
+    from matplotlib import colors
+    import matplotlib as mpl
+    import matplotlib.cm as cmx
+
+    #Get parameters
+    number_lags = myBeam.prm.mplgs
+    lags = list(set([x[1]-x[0] for x in myBeam.prm.ltab]))
+    range_gates = np.linspace(0.5,myBeam.prm.nrang+0.5,num=myBeam.prm.nrang+1)
+    power=np.array(myBeam.rawacf.pwr0)
+    noise=np.array(myBeam.prm.noisesearch)
+
+    #Make the figure and axes
+    fig=pyplot.figure()
+    ax1=fig.add_axes([0.1,0.1,0.77,0.1])
+    ax2=fig.add_axes([0.1,0.2,0.77,0.7])
+    ax3=fig.add_axes([0.88,0.2,0.02,0.7])
+
+    #Plot the SNR
+    ax1.plot(range(1,myBeam.prm.nrang+1),10*np.log10(power/noise),lw=5)
+
+    #Calculate bounds for plotting
+    lag_numbers = []
+    for lag in lags:
+        temp = [lag-0.5, lag+0.5]
+        lag_numbers.extend(temp)
+
+    #generate a scalar colormapping to map data to cmap
+    cl=[-1,1]
+    cmap='jet'
+    cNorm = colors.Normalize(vmin=cl[0], vmax=cl[1])
+    scalarMap = cmx.ScalarMappable(norm=cNorm, cmap=cmap)
+
+    #Now plot SCR data  
+    for r in range(myBeam.prm.nrang):
+
+        #Grab the appropriate data for plotting
+        if ((xcf) and (myBeam.prm.xcf == 0)):
+            print "No interferometer data available."
+            return
+        elif ((xcf) and (myBeam.prm.xcf == 1)):
+            re = np.array([x[0]/power[r] for x in myBeam.rawacf.xcfd[r]]) 
+            im = np.array([x[1]/power[r] for x in myBeam.rawacf.xcfd[r]])
+        else:
+            re = np.array([x[0]/power[r] for x in myBeam.rawacf.acfd[r]])
+            im = np.array([x[1]/power[r] for x in myBeam.rawacf.acfd[r]])
+
+      #Index needed for plotting but not incrementing on missing lags
+        i=0
+        for l in range(lags[-1]+1):
+            #Make coordinates for:
+            #Real and
+            x1 = np.array([r+0.5,r+0.5,r+1.0,r+1.0])
+            #Imaginary compenents of ACF/XCF
+            x2 = np.array([r+1.0,r+1.0,r+1.5,r+1.5])
+            y = np.array([l-0.5,l+0.5,l+0.5,l-0.5])
+
+            #If the lag isn't a "missing" lag plot the data, else plot a black square.
+            if (l in lags):
+                ax2.fill(x1,y,color=scalarMap.to_rgba(re[i]))
+                ax2.fill(x2,y,color=scalarMap.to_rgba(im[i]))
+                i+=1
+            else:
+                ax2.fill(x1,y,color='black')
+                ax2.fill(x2,y,color='black')
+
+    #Add the colorbar and label it    
+    cbar = mpl.colorbar.ColorbarBase(ax3,norm=cNorm,cmap=cmap)
+    cbar.set_label('Amplitude')
+
+    #Set plot axis labels
+    ax2.set_ylim([-0.5,lag_numbers[-1]])
+    ax2.set_yticks(np.linspace(0,lags[-1],num=lags[-1]+1))
+    ax2.set_xlim([range_gates[0],range_gates[-1]])
+    ax2.set_xticklabels([],visible=False)
+    ax2.set_ylabel('Lag Number')
+
+    #Set pwr0 plot axis labels
+    ax1.set_xlim([range_gates[0],range_gates[-1]])
+    ax1.set_ylim([0,40])
+    ax1.set_yticks(np.linspace(0,30,num=4))
+    ax1.set_ylabel(r'pwr$_{0}$''\n(dB)')
+    ax1.set_xlabel('Range Gate')
+
+    fig.show()
+
+
+
+
+def nuft(a,tn,T):
+    """A function to calculate the non-uniformly sampled discrete Fourier transform.
+
+    **Args**:
+        * **a** : (np.array) The input array to be transformed.
+        * **tn**: (float) An array of timestamps for the input array.
+        * **T**: (float) The end time of the input array.
+
+    **Returns**:
+        Nothing.
+
+        Written by ASR 20141230
+    """
+
+    import numpy as np
+    T=float(T)
+    ft=np.zeros((len(a),),np.complex)
+    for m in range(len(a)):
+        ft[m] = np.sum(a*np.exp(-1j*2*np.pi/T*m*tn))
+
+    return ft
+
+
+
+if __name__ == "__main__":
+
+    import pydarn
+    from datetime import datetime
+    from matplotlib import pyplot
+
+    print "First we need to fetch an rawacf file and read a beam record..."
+    myPtr = pydarn.sdio.radDataOpen(datetime(2012,5,21),'sas', eTime=datetime(2012,5,21,2),fileType='rawacf')
+    myBeam = myPtr.readRec()
+
+    print "Testing the plot_rli method and it's options...."
+    print "...First test default options..."
+    pydarn.plotting.acfPlot.plot_rli(myBeam)
+
+    print "...Next test with 'xcf=True'..."
+    pydarn.plotting.acfPlot.plot_rli(myBeam,xcf=True)
+
+    print "Close the figures to proceed with testing..."
+    pyplot.show()
+
+    print "Testing the plot_acf method and it's options...."
+    print "...First test default options, at range gate 31, you should see ground scatter and lags marked that are blanked by Tx blanking..."
+    pydarn.plotting.acfPlot.plot_acf(myBeam,31)
+
+    print "...Next, with 'show_blanked=False', blanking marking turned off "
+    pydarn.plotting.acfPlot.plot_acf(myBeam,31,show_blanked=False)
+
+    print "...Next, with 'xcf=True', plotting xcf data"
+    pydarn.plotting.acfPlot.plot_acf(myBeam,31,xcf=True)
+
+    fig = pyplot.figure()
+    ax = fig.add_axes([0.1,0.1,0.8,0.8])
+    print "...Next, plotting to our own axis object, 'ax=ax'"
+    pydarn.plotting.acfPlot.plot_acf(myBeam,31,ax=ax)
+
+    pyplot.show()
 

--- a/pydarn/plotting/acfPlot.py
+++ b/pydarn/plotting/acfPlot.py
@@ -123,8 +123,9 @@ def plot_acf(myBeam, gate, normalized=True, mark_blanked=True,
     acfFFT = []
     acfFFT.extend(temp[len(temp) / 2 + 1:])
     acfFFT.extend(temp[0:len(temp) / 2 + 1])
-    freq_scale_factor = 1 / (lags[-1] * myBeam.prm.mpinc * 10.0 ** -6) \
-        / (myBeam.prm.tfreq * 1000.) / 2. * (3. * 10 ** 8)
+    freq_scale_factor = ((3. * 10 ** 8) / 
+                         (myBeam.prm.tfreq * 1000. * 2. * lags[-1] *
+                          myBeam.prm.mpinc * 10.0 ** -6))
     vels = freq_scale_factor * (np.array(range(len(acfFFT))) -
                                 len(acfFFT) / 2)
 


### PR DESCRIPTION
Extends `pydarn/plotting` by adding the `plotAcf.py` file. This file provides two functions for plotting SuperDARN rawacf data, `plot_acf` and `plot_rli`. `plot_acf` visualizes the ACF/XCF for at an input range gate. `plot_rli` plots a range-lag-intensity plot, visualizing both the real and imaginary components of an ACF/XCF for an input `beamData` object.

To test this pull request, one simply needs to execute `python acfPlot.py`.

One may also test some of this code with the following:
    
    from datetime import datetime
    myPtr = pydarn.sdio.radDataOpen(datetime(2012,5,21),'sas', eTime=datetime(2012,5,21,2),fileType='rawacf')
    myBeam = myPtr.readRec()
    pydarn.plotting.acfPlot.plot_acf(myBeam,31)
    pydarn.plotting.acfPlot.plot_rli(myBeam)

The `__init__.py` file in the `pydarn/plotting` directory was modified to add an import all from `acfPlot.py`.