### PR TITLE
Added script for Fedora 21 install.

### DIFF
--- a/install/fedora_dependencies.sh
+++ b/install/fedora_dependencies.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Python install script for Fedora
+#	installs all pre-requisite software to run DaViT-py
+#	tested on Fedora 21
+
+ver=2.7
+
+dnf install -y python$ver
+dnf install -d python-dev
+dnf install -y python-pip
+dnf install -y python-zmq
+dnf install -y python-imaging
+dnf install -y mpich2
+dnf install -y gcc-gfortran
+dnf install -y hdf5-devel
+dnf install -y python-matplotlib
+pip install --upgrade matplotlib
+dnf install -y python-basemap-data
+pip install --upgrade ipython
+dnf install -y ipython-notebook
+pip install --upgrade numpy
+dnf install -y scipy
+dnf install -y geos-python
+dnf install -y geos-devel
+pip install --allow-external basemap --allow-unverified basemap--upgrade basemap	# different
+pip install --upgrade Cython
+pip install --upgrade h5py
+pip install --upgrade tornado
+pip install --upgrade paramiko
+pip install --upgrade pymongo
+pip install --upgrade mechanize
+pip install --upgrade jinja2
+pip install --upgrade ecdsa
+
+# gfortran module files need to be recompiled for this version
+cd ../models/hwm/
+rm ./*.mod
+gfortran *.f90
+
+dir=$(pwd)
+echo "source $dir/../profile.bash" >> ~/.bashrc

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ for s in source_dirs:
             sources.append('.'.join(
                 root.replace(pwd,'').strip('/').split('/')
                 ))
-print 'spurces',sources
+print 'sources',sources
 ################################################################################
 
 def read(fname):


### PR DESCRIPTION
Hey @asreimer,

Here's the commit for my Fedora install script.  Since yum has been deprecated, I only added support for dnf, although the syntax and package names are the same for both programs.  
Packages named differently than on Ubuntu:
-gcc-fortran
-hdf5-devel
-scipy
-basemap (needed to experiment with the flags to get this one to work)

Packages added:
-geos-python
-geos-devel
-Cython (this used to be installed automatically with h5py, but that breaks the install process in many instances, including mine.  Installing it explicitly first works better.)

I need to test on a clean install to make sure there aren't other dependencies that are needed that I happened to have installed, but otherwise these seem to be the only ones that are different from the Ubuntu install.