### PR TITLE
Bugfixes printRec

### DIFF
--- a/davitpy/pydarn/plotting/printRec.py
+++ b/davitpy/pydarn/plotting/printRec.py
@@ -170,6 +170,8 @@ def fitPrintRec(sTime, eTime, rad, outfile, fileType='fitex', summ=0):
   while(myData is not None and myData.time <= eTime):
     t = myData.time
     if(summ == 0):
+      # If not interested in the summary, lets print all of the range gate values.  We'll
+      # start with the header for each beam sounding.
       f.write(t.strftime("%Y-%m-%d  "))
       f.write(t.strftime("%H:%M:%S  "))
       f.write(radar.name+' ')
@@ -185,10 +187,12 @@ def fitPrintRec(sTime, eTime, rad, outfile, fileType='fitex', summ=0):
       f.write('  channel = '+str(myData.channel))
       f.write('  cpid = '+str(myData.cp)+'\n')
       
+      # Write the table column header
       f.write('{0:>4s} {13:>5s} {1:>5s} / {2:<5s} {3:>8s} {4:>3s} {5:>8s} {6:>8s} {7:>8s} {8:>8s} {9:>8s} {10:>8s} {11:>8s} {12:>8s}\n'.format \
       ('gate','pwr_0','pwr_l','vel','gsf','vel_err','width_l','geo_lat','geo_lon','geo_azm',
         'mag_lat','mag_lon','mag_azm','range'))
       
+      # Cycle through each range gate identified as having scatter in the slist
       for i in range(len(myData.fit.slist)):
 
         d = utils.geoPack.calcDistPnt(myFov.latFull[myData.bmnum][myData.fit.slist[i]],

--- a/davitpy/pydarn/plotting/printRec.py
+++ b/davitpy/pydarn/plotting/printRec.py
@@ -180,7 +180,7 @@ def fitPrintRec(sTime, eTime, rad, outfile, fileType='fitex', summ=0):
       f.write('  scan = '+str(+myData.prm.scan)+'\n')
       f.write('npnts = '+str(len(myData.fit.slist)))
       f.write('  nrang = '+str(myData.prm.nrang))
-      f.write('  channel = '+myData.channel)
+      f.write('  channel = '+str(myData.channel))
       f.write('  cpid = '+str(myData.cp)+'\n')
       
       f.write('{0:>4s} {13:>5s} {1:>5s} / {2:<5s} {3:>8s} {4:>3s} {5:>8s} {6:>8s} {7:>8s} {8:>8s} {9:>8s} {10:>8s} {11:>8s} {12:>8s}\n'.format \

--- a/davitpy/pydarn/plotting/printRec.py
+++ b/davitpy/pydarn/plotting/printRec.py
@@ -143,7 +143,7 @@ def fitPrintRec(sTime, eTime, rad, outfile, fileType='fitex', summ=0):
   from davitpy import utils
   from davitpy import models
   
-  file_format = ['{date}.hour......{radar}.{ftype}','{date}.{hour}......{radar}...{ftype}']
+  file_format = ['{date}.{hour}......{radar}.{ftype}','{date}.{hour}......{radar}...{ftype}']
   myPtr = pydarn.sdio.radDataOpen(sTime,rad,eTime=eTime,fileType=fileType,local_fnamefmt=file_format,remote_fnamefmt=file_format)
   if(myPtr is None): return None
   

--- a/davitpy/pydarn/plotting/printRec.py
+++ b/davitpy/pydarn/plotting/printRec.py
@@ -143,7 +143,8 @@ def fitPrintRec(sTime, eTime, rad, outfile, fileType='fitex', summ=0):
   from davitpy import utils
   from davitpy import models
   
-  myPtr = pydarn.sdio.radDataOpen(sTime,rad,eTime=eTime,fileType=fileType)
+  file_format = ['{date}.hour......{radar}.{ftype}','{date}.{hour}......{radar}...{ftype}']
+  myPtr = pydarn.sdio.radDataOpen(sTime,rad,eTime=eTime,fileType=fileType,local_fnamefmt=file_format,remote_fnamefmt=file_format)
   if(myPtr is None): return None
   
   myData = pydarn.sdio.radDataReadRec(myPtr)

--- a/davitpy/pydarn/plotting/printRec.py
+++ b/davitpy/pydarn/plotting/printRec.py
@@ -114,7 +114,8 @@ def readPrintRec(filename):
 
   #close the file
   fp.close()
-
+  #close the pointer created here as well
+  myPtr.close()
 
 def fitPrintRec(sTime, eTime, rad, outfile, fileType='fitex', summ=0):
   """A function to print the contents of a fit-type file

--- a/davitpy/pydarn/plotting/printRec.py
+++ b/davitpy/pydarn/plotting/printRec.py
@@ -217,9 +217,9 @@ def fitPrintRec(sTime, eTime, rad, outfile, fileType='fitex', summ=0):
                   myData.prm.frang+myData.fit.slist[i]*myData.prm.rsep))
           
       f.write('\n')
-      
+    # Else write the beam summary for each sounding      
     else:
-      f.write('{0:9s} {11:6s} {1:>4d} {2:>5d} {3:>5d} {12:>4d} {4:>7d} {5:>7s} {6:>5d} {7:>5d} {8:>5d} {9:>5.2f} {10:>4d}\n'.\
+      f.write('{0:9s} {11:6s} {1:>4d} {2:>5d} {3:>5d} {12:>4d} {4:>7d} {5:>7d} {6:>5d} {7:>5d} {8:>5d} {9:>5.2f} {10:>4d}\n'.\
       format(t.strftime("%H:%M:%S."),myData.bmnum,len(myData.fit.slist),\
       myData.prm.nrang,myData.cp,myData.channel,myData.prm.tfreq,\
       myData.prm.lagfr,myData.prm.smsep,myData.prm.inttsc+myData.prm.inttus/1e6,\

--- a/davitpy/pydarn/sdio/radDataTypes.py
+++ b/davitpy/pydarn/sdio/radDataTypes.py
@@ -854,7 +854,8 @@ class beamData(radBaseData):
     * **cp** (int): radar control program id number
     * **stid** (int): radar station id number
     * **time** (`datetime <http://tinyurl.com/bl352yx>`_): timestamp of beam sounding
-    * **channel** (str): radar operating channel, eg 'a', 'b', ...
+    * **channel** (int): radar operating channel defined by STEREO operations, eg 0, 1, 2.  Zero is for 
+    *                    non-stereo operations and 1 & 2 are for STEREO operations of A & B channels
     * **bmnum** (int): beam number
     * **prm** (:class:`pydarn.sdio.radDataTypes.prmData`): operating params
     * **fit** (:class:`pydarn.sdio.radDataTypes.fitData`): fitted params


### PR DESCRIPTION
Found a number of little bugs when trying to use the develop version of printRec today.  The biggest change here is that the beamData.channel value is an integer and not a string as it previously was.  Treating channel as a string was breaking the code is several places.  Made sure to update this in the radDataTypes documentation.  Another big thing is the radDataOpen call had not been updated to use the new formats...so the UAF.channel filenames would not be found when calling this function. Added a little bit of commenting to printRec as well.

To test, below some sample code.  I encourage you to try out radar for bks, pyk, ade, mcm in combination with changing the summ=0 value to either a 0 or 1.  summ=1 will just output a beam summary for each sounding and not all of the range gates with scatter.  This code will output the results in the out.txt file.

#!/usr/bin/env python

import os
import tempfile
os.environ['MPLCONFIGDIR'] = tempfile.mkdtemp()
import matplotlib
from davitpy import pydarn
import datetime as dt

year = 2015
month  = 8
day = 20
shr    = 0
smin = 30
ehr = 1
emin = 0
radar   = 'pyk'
filename = 'out.txt'
filetype = 'fitacf'

pydarn.plotting.printRec.fitPrintRec(dt.datetime(year,month,day,shr,smin),dt.datetime(year,month,day,ehr,emin),radar,filename,summ=0,fileType=filetype)