### PR TITLE
Closing the opened sftp connection

### DIFF
--- a/davitpy/pydarn/sdio/fetchUtils.py
+++ b/davitpy/pydarn/sdio/fetchUtils.py
@@ -699,6 +699,11 @@ def fetch_remote_files(stime, etime, method, remotesite, remotedirfmt,
     # after deleting the dictionary structure containing the password
     del remoteaccess
 
+    #--------------------------------------------------------------------------
+    # Close the opened sftp connection
+    sftp.close()
+    transport.close()
+
     return filelist
 
 

--- a/davitpy/pydarn/sdio/fetchUtils.py
+++ b/davitpy/pydarn/sdio/fetchUtils.py
@@ -701,8 +701,9 @@ def fetch_remote_files(stime, etime, method, remotesite, remotedirfmt,
 
     #--------------------------------------------------------------------------
     # Close the opened sftp connection
-    sftp.close()
-    transport.close()
+    if method is "sftp":
+	    sftp.close()
+	    transport.close()
 
     return filelist
 


### PR DESCRIPTION
I think this was related to some issues I was finding when I brought up #119 .  One of the issues was the local computer running out of memory, but that was just bad programming on my part.  Garima and I have off and on been running iterative type code which is pulling over lots of data in one go.  I believe that if you're iterating through data open calls (and even if you close the pointer) the sftp connection stays open to the sftp server.  For me this popped up as I would run my code and then a few hours later see that the sd-data1.ece.vt.edu computer had over 1000 processes on it, most of which were sshd processes for sd_dbread.  

I think this might not be an issue for most people as I think the sftp connection is closed whenever the initial process/code that started everything is done.  However, for iterative type data call and processing, it starts to be a problem.  In general, it's probably good that we close the sftp connection once we've downloaded all of the files that are needed.

I don't have a good way for people to test this that are outside of VT and know how to see the processes running on the sd-data1.ece.vt.edu sftp server.  You would have to setup your own sftp server, have some code loop through a bunch of radDataOpen calls (a start on this type of code could be pulled from #119), and then watch the number of sshd processes increase on the sftp server while the code is still running.  Flip it over to this branch and the sshd processes will go away once the files have been downloaded.  

Otherwise, you could coordinate something with me over e-mail/google-hangouts and I can watch the processes increase here while you run some code.