### PR TITLE
Release1.0 readfit

### DIFF
--- a/davitpy/pydarn/sdio/radDataTypes.py
+++ b/davitpy/pydarn/sdio/radDataTypes.py
@@ -171,9 +171,9 @@ class radDataPtr():
             else:
                 os.system('cp '+fileName+' '+outname)
                 print 'cp '+fileName+' '+outname
-            if fileType=='fit':    #If a fit file name is given, it is converted to fitacf
+            if fileType=='fit':    #If a fit file name is given, it is converted to fitacf, as our dmap routines can't read fit files
                 outname_new="_".join((outname,'fitacf'))
-                print "Converting fit to fitacf"
+                print "Can't read fit files. Converting to fitacf.."
                 os.system('fittofitacf '+outname+' > '+outname_new)
                 outname=outname_new
             filelist.append(outname)
@@ -264,6 +264,7 @@ class radDataPtr():
                                              local_fnamefmt, verbose=verbose)
 
                 if ftype=='fit':   #If fit files found, converting them to fitacf files
+                    print "Can't read fit files. Converting to fitacf.."
                     temp_new=[]
                     for f in temp:
                         new_name=string.replace(f,'fit','fitacf')
@@ -367,6 +368,7 @@ class radDataPtr():
                     password=password, port=port, verbose=verbose)
 
                 if ftype=='fit':   #If fit files found, converting them to fitacf files
+                    print "Can't read fit files. Converting to fitacf.."
                     temp_new=[]
                     for f in temp:
                         new_name=string.replace(f,'fit','fitacf')

--- a/davitpy/pydarn/sdio/radDataTypes.py
+++ b/davitpy/pydarn/sdio/radDataTypes.py
@@ -238,9 +238,7 @@ class radDataPtr():
                     local_dict = {'radar':radcode, 'ftype':ftype, 'channel':channel}
                 if ('ftype' in local_dict.keys()):
                     local_dict['ftype'] = ftype
-                #import ipdb
-                #ipdb.set_trace()
-                if ftype=='fit':
+                if local_fnamefmt is None or ftype=='fit':
                     local_fnamefmt=['{date}{hour}.*{ftype}'] #File name format for fit files
 
                 if local_fnamefmt is None or ftype!='fit':
@@ -337,7 +335,7 @@ class radDataPtr():
                 if ('ftype' in remote_dict.keys()):
                     remote_dict['ftype'] = ftype
                 
-                if ftype=='fit':   # Name for a remote fit file
+                if remote_fnamefmt is None or ftype=='fit':   # Name for a remote fit file
                     remote_fnamefmt=['{date}{hour}.*{ftype}'] 
                 if remote_fnamefmt is None or ftype!='fit':
                     try:

--- a/davitpy/pydarn/sdio/radDataTypes.py
+++ b/davitpy/pydarn/sdio/radDataTypes.py
@@ -50,7 +50,7 @@ class radDataPtr():
                          default = None meaning don't check for UAF named data files
     * **bmnum** (int): beam number of the request
     * **cp** (int): control prog id of the request
-    * **fType** (str): the file type, 'fitacf', 'rawacf', 'iqdat', 'fitex', 'lmfit'
+    * **fType** (str): the file type, 'fitacf', 'rawacf', 'iqdat', 'fitex', 'lmfit','fit'
     * **fBeam** (:class:`pydarn.sdio.radDataTypes.beamData`): the first beam of the next scan, useful for when reading into scan objects
     * **recordIndex** (dict): look up dictionary for file offsets for all records 
     * **scanStartIndex** (dict): look up dictionary for file offsets for scan start records
@@ -238,11 +238,12 @@ class radDataPtr():
                     local_dict = {'radar':radcode, 'ftype':ftype, 'channel':channel}
                 if ('ftype' in local_dict.keys()):
                     local_dict['ftype'] = ftype
-                
+                #import ipdb
+                #ipdb.set_trace()
                 if ftype=='fit':
                     local_fnamefmt=['{date}{hour}.*{ftype}'] #File name format for fit files
 
-                if local_fnamefmt is None:
+                if local_fnamefmt is None or ftype!='fit':
                     try:
                         local_fnamefmt = davitpy.rcParams['DAVIT_LOCAL_FNAMEFMT'].split(',')
                     except:
@@ -277,9 +278,6 @@ class radDataPtr():
                 valid = self.__validate_fetched(temp,self.sTime,self.eTime)
                 filelist = [x[0] for x in zip(temp,valid) if x[1]]
                 invalid_files = [x[0] for x in zip(temp,valid) if not x[1]]
-
-                import ipdb
-                ipdb.set_trace()
                 if len(invalid_files) > 0:
                     for f in invalid_files:
                         print 'removing invalid file: ' + f
@@ -338,9 +336,10 @@ class radDataPtr():
                     remote_dict = {'ftype':ftype, 'channel':channel, 'radar':radcode}
                 if ('ftype' in remote_dict.keys()):
                     remote_dict['ftype'] = ftype
+                
                 if ftype=='fit':   # Name for a remote fit file
                     remote_fnamefmt=['{date}{hour}.*{ftype}'] 
-                if remote_fnamefmt is None:
+                if remote_fnamefmt is None or ftype!='fit':
                     try:
                         remote_fnamefmt = davitpy.rcParams['DAVIT_REMOTE_FNAMEFMT'].split(',')
                     except:


### PR DESCRIPTION
After this, we will be able to read 'fit' files like we read 'fitacf' files. This routine converts a 'fit' to 'fitacf' while opening only, so that rest of the functions keep behaving in the same way as before.

from davitpy.pydarn.sdio import radDataRead
import datetime as dt

myptr=radDataRead.radDataOpen(dt.datetime(2002,8,19,1,0,0,0),'sas',dt.datetime(2002,8,19,2,0,0,0),\
channel=None,fileType='fit', filtered=False,src='sftp')

"""
Try with all these commands:
myptr=radDataRead.radDataOpen(dt.datetime(2009,8,19,1,0,0,0),'sas',dt.datetime(2009,8,19,2,0,0,0),\
channel=None,fileType='fitacf', filtered=False,src='sftp')

myptr=radDataRead.radDataOpen(dt.datetime(2002,8,19,1,0,0,0),'sas',dt.datetime(2002,8,19,2,0,0,0),\
channel=None,fileType='fit', filtered=False,src='local')

myptr=radDataRead.radDataOpen(dt.datetime(2009,8,19,1,0,0,0),'sas',dt.datetime(2009,8,19,2,0,0,0),\
channel=None,fileType='fitacf', filtered=False,src='local')

"""
x=1
mybiglist=[]
while(x!=None):
        x=radDataRead.radDataReadScan(myptr)
        mybiglist.append(x)
