### PR TITLE
Addition of Dependency Install Script for Fedora

### DIFF
--- a/install/fedora_dependencies.sh
+++ b/install/fedora_dependencies.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Python install script for Fedora
+#	installs all pre-requisite software to run DaViT-py
+#	tested on Fedora 21
+
+ver=2.7
+
+dnf install -y python$ver
+dnf install -d python-dev
+dnf install -y python-pip
+dnf install -y python-zmq
+dnf install -y python-imaging
+dnf install -y mpich2
+dnf install -y gcc-gfortran
+dnf install -y hdf5-devel
+dnf install -y python-matplotlib
+pip install --upgrade matplotlib
+dnf install -y python-basemap-data
+pip install --upgrade ipython
+dnf install -y ipython-notebook
+pip install --upgrade numpy
+dnf install -y scipy
+dnf install -y geos-python
+dnf install -y geos-devel
+pip install --allow-external basemap --allow-unverified basemap--upgrade basemap	# different
+pip install --upgrade Cython
+pip install --upgrade h5py
+pip install --upgrade tornado
+pip install --upgrade paramiko
+pip install --upgrade pymongo
+pip install --upgrade mechanize
+pip install --upgrade jinja2
+pip install --upgrade ecdsa
+
+# gfortran module files need to be recompiled for this version
+cd ../models/hwm/
+rm ./*.mod
+gfortran *.f90
+
+dir=$(pwd)
+echo "source $dir/../profile.bash" >> ~/.bashrc

--- a/install/fedora_dependencies.sh
+++ b/install/fedora_dependencies.sh
@@ -7,7 +7,7 @@
 # Installs dependencies for python 2.7.
 
 dnf install -y python
-dnf install -d python-dev
+dnf install -y python-devel
 dnf install -y python-pip
 dnf install -y python-zmq
 dnf install -y python-imaging

--- a/install/fedora_dependencies.sh
+++ b/install/fedora_dependencies.sh
@@ -2,20 +2,23 @@
 
 # Python install script for Fedora
 #	installs all pre-requisite software to run DaViT-py
-#	tested on Fedora 21
+#	tested on Fedora 21 and 22
 
-ver=2.7
+# Installs dependencies for python 2.7.
 
-dnf install -y python$ver
+dnf install -y python
 dnf install -d python-dev
 dnf install -y python-pip
 dnf install -y python-zmq
 dnf install -y python-imaging
-dnf install -y mpich2
+dnf install -y openmpi-devel
+ln -s /usr/lib64/openmpi/bin/mpif90 /usr/bin/mpif90 #Needed for raydarn to compile properly
 dnf install -y gcc-gfortran
+dnf install -y gcc-c++
 dnf install -y hdf5-devel
 dnf install -y python-matplotlib
 pip install --upgrade matplotlib
+dnf install -y python-basemap
 dnf install -y python-basemap-data
 pip install --upgrade ipython
 dnf install -y ipython-notebook
@@ -23,7 +26,6 @@ pip install --upgrade numpy
 dnf install -y scipy
 dnf install -y geos-python
 dnf install -y geos-devel
-pip install --allow-external basemap --allow-unverified basemap--upgrade basemap	# different
 pip install --upgrade Cython
 pip install --upgrade h5py
 pip install --upgrade tornado
@@ -32,11 +34,5 @@ pip install --upgrade pymongo
 pip install --upgrade mechanize
 pip install --upgrade jinja2
 pip install --upgrade ecdsa
+pip install --upgrade pandas
 
-# gfortran module files need to be recompiled for this version
-cd ../models/hwm/
-rm ./*.mod
-gfortran *.f90
-
-dir=$(pwd)
-echo "source $dir/../profile.bash" >> ~/.bashrc


### PR DESCRIPTION
This pull request adds a dependency install script for Fedora 21 and 22. The original work on building this script was performed by @bsinglet and I have included some bug fixes that enable raydarn dependencies to be installed. Also removed old code that added stuff to .bashrc since we don't need that anymore (environment variables aren't used as of 0.4-master release).

To test this, you need to start with a fresh install of Fedora 21 or 22 and then run this script.