### PR TITLE
Refactoring of timeUtils.py

### DIFF
--- a/davitpy/utils/timeUtils.py
+++ b/davitpy/utils/timeUtils.py
@@ -84,7 +84,7 @@ def yyyymmddToDate(date_str):
     assert(isinstance(date_str, str)), 'error, input must be of type str'
     assert(len(date_str) == 8), 'error, input must be of yyyymmdd format'
 
-    my_date = datetime.strptime('20121124', '%Y%m%d')
+    return datetime.strptime('20121124', '%Y%m%d')
 
 
 def timeYrsecToDate(yrsec, year):

--- a/davitpy/utils/timeUtils.py
+++ b/davitpy/utils/timeUtils.py
@@ -35,13 +35,13 @@
 """
 
 
-def dateToYyyymmdd(myDate):
+def dateToYyyymmdd(my_date):
   """takes a python datetime object and returns a string in yyyymmdd format
 
   **Args**:
-    * **myDate** (`datetime <http://tinyurl.com/bl352yx>`_): a python datetime object
+    * **my_date** (`datetime <http://tinyurl.com/bl352yx>`_): a python datetime object
   **Returns**:
-    * **dateStr** (str): a string in yyyymmdd format
+    * **date_str** (str): a string in yyyymmdd format
 
   **Example**:
     ::
@@ -50,42 +50,15 @@ def dateToYyyymmdd(myDate):
       dateStr = utils.timeUtils.dateToYyyymmdd(dt.datetime(2012,7,10))
 
   Written by AJ 20120718
+  Modified by ASR 20151120
   """
 
   from datetime import datetime
   
-  if isinstance(myDate,datetime):
-    dateStr = ''
-    #create year string
-    yr = myDate.year
-    if(yr < 10):
-      dateStr += '000'+str(yr)
-    elif(yr < 100):
-      dateStr += '00'+str(yr)
-    elif(yr < 1000):
-      dateStr += '0'+str(yr)
-    else:
-      dateStr += str(yr)
-      
-    #create month string
-    mon = myDate.month
-    if(mon < 10):
-      dateStr += '0'+str(mon)
-    else:
-      dateStr += str(mon)
-      
-    #create day string
-    day = myDate.day
-    if(day < 10):
-      dateStr += '0'+str(day)
-    else:
-      dateStr += str(day)
-      
-    #return everything together
-    return dateStr
-  else:
-    print 'error, input must be type datetime'
-    sys.exit()
+  assert(isinstance(my_date,datetime)),'error, input must be type datetime'
+  
+  return my_date.strftime('%Y%m%d')
+
   
 def yyyymmddToDate(dateStr):
   """takes a string in yyyymmdd format and returns a python date object
@@ -101,6 +74,7 @@ def yyyymmddToDate(dateStr):
       myDate = utils.timeUtils.yyyymmddToDate('20120710')
 
   Written by AJ 20120718
+  Modified by ASR 20151120
   """
   
   from datetime import datetime

--- a/davitpy/utils/timeUtils.py
+++ b/davitpy/utils/timeUtils.py
@@ -60,13 +60,13 @@ def dateToYyyymmdd(my_date):
   return my_date.strftime('%Y%m%d')
 
   
-def yyyymmddToDate(dateStr):
+def yyyymmddToDate(date_str):
   """takes a string in yyyymmdd format and returns a python date object
 
   **Args**:
-    * **dateStr** (str): a string in yyyymmdd format
+    * **date_str** (str): a string in yyyymmdd format
   **Returns**:
-    * **myDate** (`datetime <http://tinyurl.com/bl352yx>`_): a python datetime object
+    * **my_date** (`datetime <http://tinyurl.com/bl352yx>`_): a python datetime object
     
   **Example**:
     ::
@@ -78,20 +78,12 @@ def yyyymmddToDate(dateStr):
   """
   
   from datetime import datetime
-  import sys
-  #check input type
-  if isinstance(dateStr,str):
-    #try to make the date object
-    try:
-      return datetime(int(dateStr[0:4]),int(dateStr[4:6]),int(dateStr[6:8]))
-    #if there was a problem with the input
-    except:
-      print 'error in input '+dateStr 
-      sys.exit()
-  else:
-    print 'error, input must be a string'
-    sys.exit()
-    
+
+  assert(isinstance(date_str,str)),'error, input must be of type str'
+  assert(len(date_str)==8),'error, input must be of yyyymmdd format'
+
+  my_date = datetime.strptime('20121124','%Y%m%d')
+
     
 def timeYrsecToDate(yrsec, year):
   """Converts time expressed in seconds from start of year to a python DATETIME object

--- a/davitpy/utils/timeUtils.py
+++ b/davitpy/utils/timeUtils.py
@@ -47,7 +47,7 @@ def dateToYyyymmdd(my_date):
     ::
 
       import datetime as dt
-      dateStr = utils.timeUtils.dateToYyyymmdd(dt.datetime(2012,7,10))
+      date_str = utils.timeUtils.dateToYyyymmdd(dt.datetime(2012,7,10))
 
   Written by AJ 20120718
   Modified by ASR 20151120
@@ -71,7 +71,7 @@ def yyyymmddToDate(date_str):
   **Example**:
     ::
 
-      myDate = utils.timeUtils.yyyymmddToDate('20120710')
+      my_date = utils.timeUtils.yyyymmddToDate('20120710')
 
   Written by AJ 20120718
   Modified by ASR 20151120
@@ -86,30 +86,31 @@ def yyyymmddToDate(date_str):
 
     
 def timeYrsecToDate(yrsec, year):
-  """Converts time expressed in seconds from start of year to a python DATETIME object
+  """Converts time expressed in seconds from start of year to a python datetime object
 
   **Args**:
     * **yrsec** (int): seconds since start of year
     * **year** (int): year in YYYY 
   **Returns**:
-    * **myDate** (`datetime <http://tinyurl.com/bl352yx>`_): a python DATETIME object.
+    * **my_date** (`datetime <http://tinyurl.com/bl352yx>`_): a python datetime object.
 
   **Example**:
     ::
 
-      myDate = utils.timeUtils.timeYrsecToDate(1205304,2012)
+      my_date = utils.timeUtils.timeYrsecToDate(1205304,2012)
 
   Written by Sebastien, Jul. 2012
+  Modified by ASR 20151120
   """
+
   from datetime import datetime
   from datetime import timedelta
-  
-  if year >= 2038: 
-    print 'timeYrsecToDate: Year {:d} out of range: forcing 2038'.format(year)
-    year = 2038
-  myDate = datetime(year, 1, 1) + timedelta(seconds = yrsec)
-  
-  return myDate
+
+  assert(isinstance(yrsec,int)),'error, yrsec must be of type int'
+  assert(isinstance(year,int)),'error, year must be of type int'
+
+  return datetime(year, 1, 1) + timedelta(seconds = yrsec)
+
 
 def julToDatetime( ndarray ) :
   """Convert a julian date to a datetime object.

--- a/davitpy/utils/timeUtils.py
+++ b/davitpy/utils/timeUtils.py
@@ -1,22 +1,22 @@
 # Copyright (C) 2012  VT SuperDARN Lab
 # Full license can be found in LICENSE.txt
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 .. module:: timeUtils
-   :synopsis: A module for manipulating time representations
+    :synopsis: A module for manipulating time representations
 
 .. moduleauthor:: VTSD Lab
 
@@ -24,259 +24,278 @@
 **Module**: utils.timeUtils
 ****************************
 **Functions**:
-  * :func:`utils.timeUtils.dateToDecYear`
-  * :func:`utils.timeUtils.dateToYyyymmdd`
-  * :func:`utils.timeUtils.datetimeToEpoch`
-  * :func:`utils.timeUtils.julToDatetime`
-  * :func:`utils.timeUtils.parseDate`
-  * :func:`utils.timeUtils.parseTime`
-  * :func:`utils.timeUtils.timeYrsecToDate`
-  * :func:`utils.timeUtils.yyyymmddToDate`
+    * :func:`utils.timeUtils.dateToDecYear`
+    * :func:`utils.timeUtils.dateToYyyymmdd`
+    * :func:`utils.timeUtils.datetimeToEpoch`
+    * :func:`utils.timeUtils.julToDatetime`
+    * :func:`utils.timeUtils.parseDate`
+    * :func:`utils.timeUtils.parseTime`
+    * :func:`utils.timeUtils.timeYrsecToDate`
+    * :func:`utils.timeUtils.yyyymmddToDate`
 """
 
 
 def dateToYyyymmdd(my_date):
-  """takes a python datetime object and returns a string in yyyymmdd format
+    """Takes a python datetime object and returns a string in yyyymmdd format
 
-  **Args**:
-    * **my_date** (`datetime <http://tinyurl.com/bl352yx>`_): a python datetime object
-  **Returns**:
-    * **date_str** (str): a string in yyyymmdd format
+    **Args**:
+        * **my_date** (`datetime <http://tinyurl.com/bl352yx>`_): a python
+        datetime object
+    **Returns**:
+        * **date_str** (str): a string in yyyymmdd format
 
-  **Example**:
-    ::
+    **Example**:
+        ::
 
-      import datetime as dt
-      date_str = utils.timeUtils.dateToYyyymmdd(dt.datetime(2012,7,10))
+            import datetime as dt
+            date_str = utils.timeUtils.dateToYyyymmdd(dt.datetime(2012,7,10))
 
-  Written by AJ 20120718
-  Modified by ASR 20151120
-  """
+    Written by AJ 20120718
+    Modified by ASR 20151120
+    """
 
-  from datetime import datetime
-  
-  assert(isinstance(my_date,datetime)),'error, input must be type datetime'
-  
-  return my_date.strftime('%Y%m%d')
+    from datetime import datetime
 
-  
+    assert(isinstance(my_date, datetime)), 'error, input must be type datetime'
+
+    return my_date.strftime('%Y%m%d')
+
+
 def yyyymmddToDate(date_str):
-  """takes a string in yyyymmdd format and returns a python date object
+    """takes a string in yyyymmdd format and returns a python date object
 
-  **Args**:
-    * **date_str** (str): a string in yyyymmdd format
-  **Returns**:
-    * **my_date** (`datetime <http://tinyurl.com/bl352yx>`_): a python datetime object
-    
-  **Example**:
-    ::
+    **Args**:
+        * **date_str** (str): a string in yyyymmdd format
+    **Returns**:
+        * **my_date** (`datetime <http://tinyurl.com/bl352yx>`_): a python
+        datetime object
 
-      my_date = utils.timeUtils.yyyymmddToDate('20120710')
+    **Example**:
+        ::
 
-  Written by AJ 20120718
-  Modified by ASR 20151120
-  """
-  
-  from datetime import datetime
+            my_date = utils.timeUtils.yyyymmddToDate('20120710')
 
-  assert(isinstance(date_str,str)),'error, input must be of type str'
-  assert(len(date_str)==8),'error, input must be of yyyymmdd format'
+    Written by AJ 20120718
+    Modified by ASR 20151120
+    """
 
-  my_date = datetime.strptime('20121124','%Y%m%d')
+    from datetime import datetime
 
-    
+    assert(isinstance(date_str, str)), 'error, input must be of type str'
+    assert(len(date_str) == 8), 'error, input must be of yyyymmdd format'
+
+    my_date = datetime.strptime('20121124', '%Y%m%d')
+
+
 def timeYrsecToDate(yrsec, year):
-  """Converts time expressed in seconds from start of year to a python datetime object
+    """Converts time expressed in seconds from start of year to a python
+    datetime object
 
-  **Args**:
-    * **yrsec** (int): seconds since start of year
-    * **year** (int): year in YYYY 
-  **Returns**:
-    * **my_date** (`datetime <http://tinyurl.com/bl352yx>`_): a python datetime object.
+    **Args**:
+        * **yrsec** (int): seconds since start of year
+        * **year** (int): year in YYYY
+    **Returns**:
+        * **my_date** (`datetime <http://tinyurl.com/bl352yx>`_): a python
+        datetime object.
 
-  **Example**:
-    ::
+    **Example**:
+        ::
 
-      my_date = utils.timeUtils.timeYrsecToDate(1205304,2012)
+            my_date = utils.timeUtils.timeYrsecToDate(1205304,2012)
 
-  Written by Sebastien, Jul. 2012
-  Modified by ASR 20151120
-  """
+    Written by Sebastien, Jul. 2012
+    Modified by ASR 20151120
+    """
 
-  from datetime import datetime
-  from datetime import timedelta
+    from datetime import datetime
+    from datetime import timedelta
 
-  assert(isinstance(yrsec,int)),'error, yrsec must be of type int'
-  assert(isinstance(year,int)),'error, year must be of type int'
+    assert(isinstance(yrsec, int)), 'error, yrsec must be of type int'
+    assert(isinstance(year, int)), 'error, year must be of type int'
 
-  return datetime(year, 1, 1) + timedelta(seconds = yrsec)
+    return datetime(year, 1, 1) + timedelta(seconds=yrsec)
 
 
-def julToDatetime(ndarray) :
-  """Convert a julian date to a datetime object.
+def julToDatetime(ndarray):
+    """Convert a julian date to a datetime object.
 
-  **Args**: 
-    * **NDARRAY** (float or list): single float64 or a numpy array of Julian Dates.
-  **Returns**:
-    * **dt** (list): list of datetime objects
+    **Args**:
+        * **NDARRAY** (float or list): single float64 or a numpy array of
+        Julian Dates.
+    **Returns**:
+        * **dt** (list): list of datetime objects
 
-  **Example**:
-    ::
+    **Example**:
+        ::
 
-      myDateList = utils.timeUtils.julToDatetime(2456118.5)
+            myDateList = utils.timeUtils.julToDatetime(2456118.5)
 
-  Created by Nathaniel Frissell 20120810
-  """
-  import datetime
-  import dateutil.parser
-  import numpy
-  import spacepy.time as spt
+    Created by Nathaniel Frissell 20120810
+    """
+    import datetime
+    import dateutil.parser
+    import numpy
+    import spacepy.time as spt
 
-  t = spt.Ticktock(ndarray,'JD')
+    t = spt.Ticktock(ndarray, 'JD')
 
-  dt = list()
-  for iso in t.ISO: dt.append(dateutil.parser.parse(iso))
+    dt = list()
+    for iso in t.ISO:
+        dt.append(dateutil.parser.parse(iso))
 
-  return dt
-  
-  
+    return dt
+
+
 def datetimeToEpoch(my_date):
-  """reads in a datetime and outputs the equivalent epoch time
+    """reads in a datetime and outputs the equivalent epoch time
 
-  **Args**:
-    * **my_date** (`datetime <http://tinyurl.com/bl352yx>`_): a datetime object
-  **Returns**:
-    * **my_epoch** (float or list of floats): an epoch time equal to the datetime object
-  
-  **Example**
-    ::
+    **Args**:
+        * **my_date** (`datetime <http://tinyurl.com/bl352yx>`_): a datetime
+        object
+    **Returns**:
+        * **my_epoch** (float or list of floats): an epoch time equal to the
+        datetime object
 
-      import datetime as dt
-      my_epoch = utils.timeUtils.datetimeToEpoch(dt.datetime(2012,7,10))
+    **Example**
+        ::
 
-  Written by AJ 20120914
-  Modified by Nathaniel Frissell 20130729 - Added list support.
-  Modified by AJ 20130925 - fixed local time bug with conversion
-  Modified by Nathaniel Frissell 20130930 - Fixed list support.
-  Modified by ASR 20151120
-  """
-  from datetime import datetime
-  import calendar
-  import numpy as np
+            import datetime as dt
+            my_epoch = utils.timeUtils.datetimeToEpoch(dt.datetime(2012,7,10))
 
-  assert(isinstance(my_date,(list,datetime))),'error, input must be of type datetime or list of datetimes'
-  if isinstance(my_date,list):
-    for dt in my_date:
-      assert(isinstance(dt,datetime)),'error, each member of my_date list must be of type datetime'
+    Written by AJ 20120914
+    Modified by Nathaniel Frissell 20130729 - Added list support.
+    Modified by AJ 20130925 - fixed local time bug with conversion
+    Modified by Nathaniel Frissell 20130930 - Fixed list support.
+    Modified by ASR 20151120
+    """
+    from datetime import datetime
+    import calendar
+    import numpy as np
 
-  if isinstance(my_date,datetime):
-    unx = calendar.timegm(my_date.timetuple())+my_date.microsecond/1e6
-  else:
-    unx = [calendar.timegm(dt.timetuple())+dt.microsecond/1e6 for dt in my_date]
+    assert(isinstance(my_date, (list, datetime))), \
+        'error, input must be of type datetime or list of datetimes'
+    if isinstance(my_date, list):
+        for dt in my_date:
+            assert(isinstance(dt, datetime)), \
+                'error, each member of my_date list must be of type datetime'
 
-  return unx
+    if isinstance(my_date, datetime):
+        unx = calendar.timegm(my_date.timetuple()) + my_date.microsecond / 1e6
+    else:
+        unx = [calendar.timegm(dt.timetuple()) +
+               dt.microsecond / 1e6 for dt in my_date]
+
+    return unx
+
 
 def dateToDecYear(date):
-  """Convert (`datetime <http://tinyurl.com/bl352yx>`_) object to decimal year
-  
-  **Args**: 
-    * **date** (`datetime <http://tinyurl.com/bl352yx>`_): date and time
-  **Returns**:
-    * **dyear** (float): decimal year
+    """Convert (`datetime <http://tinyurl.com/bl352yx>`_) object to decimal year
 
-  **Example**
-    ::
+    **Args**:
+      * **date** (`datetime <http://tinyurl.com/bl352yx>`_): date and time
+    **Returns**:
+      * **dyear** (float): decimal year
 
-      import datetime as dt
-      decYr = utils.timeUtils.dateToDecYear(dt.datetime(2012,7,10))
+    **Example**
+      ::
 
-  written by Sebastien, 2013-02
-  """
-  from datetime import datetime as dt
-  import time
-  
-  # returns seconds since epoch
-  sE = lambda date: time.mktime(date.timetuple())
+        import datetime as dt
+        decYr = utils.timeUtils.dateToDecYear(dt.datetime(2012,7,10))
 
-  year = date.year
-  startOfThisYear = dt(year=year, month=1, day=1)
-  startOfNextYear = dt(year=year+1, month=1, day=1)
+    written by Sebastien, 2013-02
+    """
+    from datetime import datetime as dt
+    import time
 
-  yearElapsed = sE(date) - sE(startOfThisYear)
-  yearDuration = sE(startOfNextYear) - sE(startOfThisYear)
-  fraction = yearElapsed/yearDuration
+    # returns seconds since epoch
+    sE = lambda date: time.mktime(date.timetuple())
 
-  return date.year + fraction
+    year = date.year
+    startOfThisYear = dt(year=year, month=1, day=1)
+    startOfNextYear = dt(year=year + 1, month=1, day=1)
 
-def parseDate( date ) : 
-  """ Parse YYYYMMDD dates in YYYY, MM, DD and vice versa
+    yearElapsed = sE(date) - sE(startOfThisYear)
+    yearDuration = sE(startOfNextYear) - sE(startOfThisYear)
+    fraction = yearElapsed / yearDuration
 
-  **Args**:
-    * **date** (str or list): experiment date in YYYYMMDD or [YYYY,MM,DD]
-  **Returns**:
-    * **tdate** (list or int): experiment date in [YYYY,MM,DD] or YYYYMMDD
-
-  **Example**:
-    ::
-
-      tlist = utils.timeUtils.parseDate('20120710')
-      ttime = utils.timeUtils.parseDate([2012,07,10])
-
-  Created by Sebastien
-  """
-  # transform date into an array for testing
-  if not isinstance(date, list): date = [date]
-
-  # make sure we are getting integers
-  for id in range( len(date) ):
-    if isinstance(date[id], str): date[id] = int(date[id])
-
-  # parse date one way or another
-  if len(date) == 3:
-    tdate = date[0]*10000 + date[1]*100 + date[2]
-  elif len(date) == 1:
-    tdate = [date[0]/10000, date[0]/100-date[0]/10000*100, date[0]-date[0]/100*100]
-  else:
-    print 'Invalid date format: ', date
-    return
-
-  return tdate
+    return date.year + fraction
 
 
-def parseTime( time ) : 
-  """ Parse HHMM or HHMMSS dates in HH, MM, SS and vice versa
+def parseDate(date):
+    """ Parse YYYYMMDD dates in YYYY, MM, DD and vice versa
 
-  **Args**:
-    * **TIME** (str or list): time in HHMM or HHMMSS OR [HH,MM] or [HH,MM,SS]
-  **Returns** 
-    * **ttime** (list or int): time in [HH,MM] or [HH,MM,SS] OR HHMM or HHMMSS
+    **Args**:
+      * **date** (str or list): experiment date in YYYYMMDD or [YYYY,MM,DD]
+    **Returns**:
+      * **tdate** (list or int): experiment date in [YYYY,MM,DD] or YYYYMMDD
 
-  **Example**:
-    ::
+    **Example**:
+      ::
 
-      tlist = utils.timeUtils.parseDate('065022')
-      tstr = utils.timeUtils.parseDate([6,50,22])
+        tlist = utils.timeUtils.parseDate('20120710')
+        ttime = utils.timeUtils.parseDate([2012,07,10])
 
-  Created by Sebastien
-  """
-  # transform time into an array for testing
-  if not isinstance(time, list): time = [time]
+    Created by Sebastien
+    """
+    # transform date into an array for testing
+    if not isinstance(date, list):
+        date = [date]
 
-  # make sure we are getting integers
-  for it in range( len(time) ):
-    if isinstance(time[it], str): time[it] = int(time[it])
+    # make sure we are getting integers
+    for id in range(len(date)):
+        if isinstance(date[id], str):
+            date[id] = int(date[id])
 
-  # parse time one way or another
-  if len(time) == 3:
-    ttime = time[0]*10000 + time[1]*100 + time[2]
-  elif len(time) == 2:
-    ttime = time[0]*100 + time[1]
-  elif len(time) == 1 and len(str(time[0])) > 4 and len(str(time[0])) <= 6:
-    ttime = [time[0]/10000, time[0]/100-time[0]/10000*100, time[0]-time[0]/100*100]
-  elif len(time) == 1 and len(str(time[0])) >=1  and len(str(time[0])) <= 4:
-    ttime = [time[0]/100, time[0]-time[0]/100*100]
-  else:
-    print 'Invalid time format: ', time
-    return
+    # parse date one way or another
+    if len(date) == 3:
+        tdate = date[0] * 10000 + date[1] * 100 + date[2]
+    elif len(date) == 1:
+        tdate = [date[0] / 10000, date[0] / 100 - date[0] /
+                 10000 * 100, date[0] - date[0] / 100 * 100]
+    else:
+        print 'Invalid date format: ', date
+        return
 
-  return ttime
+    return tdate
+
+
+def parseTime(time):
+    """ Parse HHMM or HHMMSS dates in HH, MM, SS and vice versa
+
+    **Args**:
+      * **TIME** (str or list): time in HHMM or HHMMSS OR [HH,MM] or [HH,MM,SS]
+    **Returns** 
+      * **ttime** (list or int): time in [HH,MM] or [HH,MM,SS] OR HHMM or HHMMSS
+
+    **Example**:
+      ::
+
+        tlist = utils.timeUtils.parseDate('065022')
+        tstr = utils.timeUtils.parseDate([6,50,22])
+
+    Created by Sebastien
+    """
+    # transform time into an array for testing
+    if not isinstance(time, list):
+        time = [time]
+
+    # make sure we are getting integers
+    for it in range(len(time)):
+        if isinstance(time[it], str):
+            time[it] = int(time[it])
+
+    # parse time one way or another
+    if len(time) == 3:
+        ttime = time[0] * 10000 + time[1] * 100 + time[2]
+    elif len(time) == 2:
+        ttime = time[0] * 100 + time[1]
+    elif len(time) == 1 and len(str(time[0])) > 4 and len(str(time[0])) <= 6:
+        ttime = [time[0] / 10000, time[0] / 100 - time[0] /
+                 10000 * 100, time[0] - time[0] / 100 * 100]
+    elif len(time) == 1 and len(str(time[0])) >= 1 and len(str(time[0])) <= 4:
+        ttime = [time[0] / 100, time[0] - time[0] / 100 * 100]
+    else:
+        print 'Invalid time format: ', time
+        return
+
+    return ttime

--- a/davitpy/utils/timeUtils.py
+++ b/davitpy/utils/timeUtils.py
@@ -112,7 +112,7 @@ def timeYrsecToDate(yrsec, year):
   return datetime(year, 1, 1) + timedelta(seconds = yrsec)
 
 
-def julToDatetime( ndarray ) :
+def julToDatetime(ndarray) :
   """Convert a julian date to a datetime object.
 
   **Args**: 
@@ -140,33 +140,39 @@ def julToDatetime( ndarray ) :
   return dt
   
   
-def datetimeToEpoch(myDate):
+def datetimeToEpoch(my_date):
   """reads in a datetime and outputs the equivalent epoch time
 
   **Args**:
-    * **myDate** (`datetime <http://tinyurl.com/bl352yx>`_): a datetime object
+    * **my_date** (`datetime <http://tinyurl.com/bl352yx>`_): a datetime object
   **Returns**:
-    * **myEpoch** (float): an epoch time equal to the datetime object
+    * **my_epoch** (float or list of floats): an epoch time equal to the datetime object
   
   **Example**
     ::
 
       import datetime as dt
-      epoch = utils.timeUtils.datetimeToEpoch(dt.datetime(2012,7,10))
+      my_epoch = utils.timeUtils.datetimeToEpoch(dt.datetime(2012,7,10))
 
   Written by AJ 20120914
   Modified by Nathaniel Frissell 20130729 - Added list support.
   Modified by AJ 20130925 - fixed local time bug with conversion
   Modified by Nathaniel Frissell 20130930 - Fixed list support.
+  Modified by ASR 20151120
   """
-  import datetime
+  from datetime import datetime
   import calendar
-  import numpy
+  import numpy as np
 
-  if numpy.size(myDate) == 1:
-    unx = calendar.timegm(myDate.timetuple())+myDate.microsecond/1e6
+  assert(isinstance(my_date,(list,datetime))),'error, input must be of type datetime or list of datetimes'
+  if isinstance(my_date,list):
+    for dt in my_date:
+      assert(isinstance(dt,datetime)),'error, each member of my_date list must be of type datetime'
+
+  if isinstance(my_date,datetime):
+    unx = calendar.timegm(my_date.timetuple())+my_date.microsecond/1e6
   else:
-    unx = [calendar.timegm(dt.timetuple())+dt.microsecond/1e6 for dt in myDate]
+    unx = [calendar.timegm(dt.timetuple())+dt.microsecond/1e6 for dt in my_date]
 
   return unx
 

--- a/davitpy/utils/timeUtils.py
+++ b/davitpy/utils/timeUtils.py
@@ -189,7 +189,8 @@ def datetimeToEpoch(my_date):
 
 
 def dateToDecYear(date):
-    """Convert (`datetime <http://tinyurl.com/bl352yx>`_) object to decimal year
+    """Convert (`datetime <http://tinyurl.com/bl352yx>`_) object to decimal
+        year
 
     **Args**:
       * **date** (`datetime <http://tinyurl.com/bl352yx>`_): date and time
@@ -264,8 +265,9 @@ def parseTime(time):
 
     **Args**:
       * **TIME** (str or list): time in HHMM or HHMMSS OR [HH,MM] or [HH,MM,SS]
-    **Returns** 
-      * **ttime** (list or int): time in [HH,MM] or [HH,MM,SS] OR HHMM or HHMMSS
+    **Returns**
+      * **ttime** (list or int): time in [HH,MM] or [HH,MM,SS] OR HHMM
+                                 or HHMMSS
 
     **Example**:
       ::

--- a/davitpy/utils/timeUtils.py
+++ b/davitpy/utils/timeUtils.py
@@ -84,7 +84,7 @@ def yyyymmddToDate(date_str):
     assert(isinstance(date_str, str)), 'error, input must be of type str'
     assert(len(date_str) == 8), 'error, input must be of yyyymmdd format'
 
-    return datetime.strptime('20121124', '%Y%m%d')
+    return datetime.strptime(date_str, '%Y%m%d')
 
 
 def timeYrsecToDate(yrsec, year):


### PR DESCRIPTION
This pull request mostly just implements PEP8 compliance for the methods contained in `timeUtils.py`. Some of the code was refactored to implement input sensitization and utilize built-in methods (for example, using `datetime`'s `strftime` method) instead.

I have tested (almost) every method in the `timeUtils.py` file. I'll be opening an issue to discuss the `spacepy` dependence in timeUtils. I'm not sure we necessarily need it (I think we should strive to minimize dependencies).

Here's what I did to test the code, see if you get the same output:

    from datetime import datetime
    from davitpy.utils import timeUtils
    
    timeUtils.dateToYyyymmdd(datetime(2012,11,24))
    timeUtils.yyyymmddToDate('20121124')
    timeUtils.timeYrsecToDate(3600, 2012)
    timeUtils.datetimeToEpoch([datetime(2012,11,24)])
    timeUtils.datetimeToEpoch(datetime(2012,11,24))
    timeUtils.dateToDecYear(datetime(2012,1,1,1))
    

And here's the respective output that you should get.

>
>'20121124'
>datetime.datetime(2012, 11, 24, 0, 0)
>datetime.datetime(2012, 1, 1, 1, 0)
>[1353715200.0]
>1353715200.0
>2012.0001138433515
>
>