### PR TITLE
rewrite readScan to handle patterned scans

### DIFF
--- a/davitpy/pydarn/sdio/radDataTypes.py
+++ b/davitpy/pydarn/sdio/radDataTypes.py
@@ -575,7 +575,7 @@ class radDataPtr():
 
     # myBeam is now the first beam we encountered where scan flag is set
     myScan.append(myBeam)
-    firstBeam = myBeam.bmnum
+    firstBeamNum = myBeam.bmnum
 
     # get the rest of the beams in the scan
     while True:
@@ -594,7 +594,7 @@ class radDataPtr():
         #   scan flags:    [1, 1, 0, 0, 0, 0, ...]
         #   beam numbers:  [5, 0, 5, 1, 5, 2, ...]
         # and we don't want to break out on the 2nd beam in this case.
-        if myBeam.prm.scan and myBeam.bmnum == firstBeam:  # if start of (next) scan
+        if myBeam.prm.scan and myBeam.bmnum == firstBeamNum:  # if start of (next) scan
             # revert offset to start of scan and break out of loop
             pydarn.dmapio.setDmapOffset(self.__fd, offset)
             break

--- a/davitpy/pydarn/sdio/radDataTypes.py
+++ b/davitpy/pydarn/sdio/radDataTypes.py
@@ -550,11 +550,8 @@ class radDataPtr():
     from davitpy.pydarn.sdio import scanData
     from davitpy import pydarn
 
-    assert((firstBeam is None and useEvery is None) or 
-           (firstBeam is not None and useEvery is not None)), \
-          'error, firstBeam and useEvery must both either be None or specified'
-    assert(isinstance(warnNonStandard,bool)), 'error, warnNonStandard must be of type bool'
-    assert(isinstance(showBeams,bool)), 'error, showBeams must be of type bool'
+    if None in [firstBeam, useEvery] and firstBeam is not useEvery:
+        raise ValueError('firstBeam and useEvery must both either be None or specified')
 
     #Save the radDataPtr's bmnum setting temporarily and set it to None
     orig_beam = self.bmnum

--- a/davitpy/pydarn/sdio/radDataTypes.py
+++ b/davitpy/pydarn/sdio/radDataTypes.py
@@ -614,7 +614,7 @@ class radDataPtr():
     # try to find the scan pattern automatically
     import itertools
     import numpy as np
-    for firstBeam, useEvery in itertools.product(range(10), range(1, 10)):
+    for firstBeam, useEvery in itertools.product(range(24), range(1, 24)):
         scan = myScan[firstBeam::useEvery]
         bmnums = [beam.bmnum for beam in scan]
         # assume correct pattern if beam numbers are increasing/decreasing by one

--- a/davitpy/pydarn/sdio/radDataTypes.py
+++ b/davitpy/pydarn/sdio/radDataTypes.py
@@ -508,7 +508,9 @@ class radDataPtr():
       return setDmapOffset(self.__fd,0)
 
   def readScan(self, firstBeam=None, useEvery=None, warnNonStandard=True, showBeams=False):
-    """A function to read a full scan of data from a :class:`pydarn.sdio.radDataTypes.radDataPtr` object
+    """A function to read a full scan of data from a :class:`pydarn.sdio.radDataTypes.radDataPtr` object. 
+    This function is capable of reading standard scans and extracting standard scans from patterned or 
+    interleaved scans (see Notes).
 
     .. note::
       This will ignore any bmnum request in :func:`~pydarn.sdio.radDataRead.radDataOpen`.
@@ -517,9 +519,11 @@ class radDataPtr():
     Parameters
     ----------
     firstBeam : int, optional
-        If manually specifying a scan pattern, will start picking beams at this index in the scan
+        If manually specifying a scan pattern, will start picking beams at this index in the scan. 
+        Requires useEvery to also be specified.
     useEvery : int, optional
-        If manually specifying a scan pattern, will pick every `useEvery` beam
+        If manually specifying a scan pattern, will pick every `useEvery` beam. Requires firstBeam
+        to also be specified.
     warnNonStandard : bool, optional
         If True, display a warning when auto-detecting a non-standard scan pattern
         (``firstBeam != 0`` or ``useEvery != 1``)
@@ -545,6 +549,12 @@ class radDataPtr():
 
     from davitpy.pydarn.sdio import scanData
     from davitpy import pydarn
+
+    assert((firstBeam is None and useEvery is None) or 
+           (firstBeam is not None and useEvery is not None)), \
+          'error, firstBeam and useEvery must both either be None or specified'
+    assert(isinstance(warnNonStandard,bool)), 'error, warnNonStandard must be of type bool'
+    assert(isinstance(showBeams,bool)), 'error, showBeams must be of type bool'
 
     #Save the radDataPtr's bmnum setting temporarily and set it to None
     orig_beam = self.bmnum

--- a/davitpy/pydarn/sdio/radDataTypes.py
+++ b/davitpy/pydarn/sdio/radDataTypes.py
@@ -507,7 +507,7 @@ class radDataPtr():
       from davitpy.pydarn.dmapio import setDmapOffset 
       return setDmapOffset(self.__fd,0)
 
-  def readScan(self, firstBeam=None, useEvery=None, showBeams=False):
+  def readScan(self, firstBeam=None, useEvery=None, warnNonStandard=True, showBeams=False):
     """A function to read a full scan of data from a :class:`pydarn.sdio.radDataTypes.radDataPtr` object
 
     .. note::
@@ -520,6 +520,9 @@ class radDataPtr():
             If manually specifying a scan pattern, will start picking beams at this index in the scan
         useEvery : int, optional
             If manually specifying a scan pattern, will pick every `useEvery` beam
+        warnNonStandard : bool, optional
+            If True, display a warning when auto-detecting a non-standard scan pattern
+            (``firstBeam != 0`` or ``useEvery != 1``)
         showBeams : bool, optional
             `showBeams` will print the collected scan numbers. Useful for debugging or if you manually want to
             find the correct combination of `firstBeam` and `useEvery`.
@@ -617,7 +620,7 @@ class radDataPtr():
         # assume correct pattern if beam numbers are increasing/decreasing by one
         # throughout the scan
         if np.all(np.diff(bmnums) == 1) or np.all(np.diff(bmnums) == -1):
-            if showBeams:
+            if showBeams or (warnNonStandard and (firstBeam != 0 or useEvery != 1)):
                 print('Auto-detected scan pattern with firstBeam={}, useEvery={}, beam numbers are {}'.format(
                     firstBeam, useEvery, list(beam.bmnum for beam in scan)))
             return scan or None  # return None if scan is empty

--- a/davitpy/pydarn/sdio/radDataTypes.py
+++ b/davitpy/pydarn/sdio/radDataTypes.py
@@ -516,21 +516,21 @@ class radDataPtr():
 
     Parameters
     ----------
-        firstBeam : int, optional
-            If manually specifying a scan pattern, will start picking beams at this index in the scan
-        useEvery : int, optional
-            If manually specifying a scan pattern, will pick every `useEvery` beam
-        warnNonStandard : bool, optional
-            If True, display a warning when auto-detecting a non-standard scan pattern
-            (``firstBeam != 0`` or ``useEvery != 1``)
-        showBeams : bool, optional
-            `showBeams` will print the collected scan numbers. Useful for debugging or if you manually want to
-            find the correct combination of `firstBeam` and `useEvery`.
+    firstBeam : int, optional
+        If manually specifying a scan pattern, will start picking beams at this index in the scan
+    useEvery : int, optional
+        If manually specifying a scan pattern, will pick every `useEvery` beam
+    warnNonStandard : bool, optional
+        If True, display a warning when auto-detecting a non-standard scan pattern
+        (``firstBeam != 0`` or ``useEvery != 1``)
+    showBeams : bool, optional
+        `showBeams` will print the collected scan numbers. Useful for debugging or if you manually want to
+        find the correct combination of `firstBeam` and `useEvery`.
 
     Returns
     -------
-        myScan : :class:`~pydarn.sdio.radDataTypes.scanData` or None
-            A sequence of beams (``None`` when no more data are available)
+    myScan : :class:`~pydarn.sdio.radDataTypes.scanData` or None
+        A sequence of beams (``None`` when no more data are available)
 
     Notes
     -----


### PR DESCRIPTION
fixes #181
fixes #182
fixes #183

Changes:
* complete rewrite of readScan
* detects new scan based on non-zero scan flag AND same
  beam number as start of previous scan (see [code comment](https://github.com/vtsuperdarn/davitpy/blob/76be9a18571aaa278951d48f87ce847ea3d8d895/davitpy/pydarn/sdio/radDataTypes.py#L586-L593))
* manual scan pattern possible by specifying first beam
  (firstBeam) and every N beams (useEvery)
* automatic scan pattern detection by looping through some
  values of firstBeam and useEvery and checking for increasing
  or decreasing beam numbers in the resulting subset of beams
* raises ValueError if automatic detection failed
* tested and works for some consecutive scans from pyk and han
  at `datetime(2013, 11, 3, 19, 0)`