### PR TITLE
Freetype dependency in matplotlib (#234)

### DIFF
--- a/install/debian_dependencies.sh
+++ b/install/debian_dependencies.sh
@@ -14,6 +14,7 @@ apt-get install -y python-imaging
 apt-get install -y mpich2
 apt-get install -y gfortran
 apt-get install -y libhdf5-serial-dev
+apt-get install -y libfreetype6-dev 
 apt-get install -y python-matplotlib
 pip install --upgrade matplotlib
 apt-get install -y python-mpltoolkits.basemap


### PR DESCRIPTION
Matplotlib requires freetype in order to compile properly. This dependency was missing in the `debian_dependencies.sh` script.