### PR TITLE
Bugfix rbsp website update

### DIFF
--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -648,8 +648,8 @@ if __name__ == '__main__':
         print ""
         print "Testing footprint collection and apogee calculation..."
         print ""
-        sTime = datetime(2016, 7, 2, 0)
-        eTime = datetime(2016, 7, 2, 12)
+        sTime = datetime(2016, 6, 2, 0)
+        eTime = datetime(2016, 6, 2, 12)
 #        fps = rbsp.rbspFp(sTime, eTime, force_web_read=True)
         fps = rbsp.rbspFp(sTime, eTime)
         print ""
@@ -657,8 +657,26 @@ if __name__ == '__main__':
         print ""
         # Pretty print the apogees in that period
         print fps
+        print "Expected results for orbits on June 2, 2016  between"
+        print "00:00 and 12:00 utc:"
+        print "    07:45 UT, B: ( 57.82 N, 314.19 E)      (-72.89 N, 351.06 E)"
+        print "    08:45 UT, A: ( 56.43 N, 307.07 E)      (-74.73 N, 337.82 E)"        
+        raw_input("Enter to continue on to another example")
+
+        print ""
+        print "Forcing a re-read from the JHU/APL website"
+        sTime = datetime(2016, 7, 2, 0)
+        eTime = datetime(2016, 7, 2, 12)
+        fps = rbsp.rbspFp(sTime, eTime, force_web_read=True)
+#        fps = rbsp.rbspFp(sTime, eTime)
+        print ""
+        print "Calculated results:"
+        print ""
+        # Pretty print the apogees in that period
+        print fps
         print "Expected results for orbits on July 2, 2016  between"
         print "00:00 and 12:00 utc:"
-        print "    01:45 UT,            106.23 E)"
-        print "    01:55                         "
+        print "    04:50 UT, A: ( 62.90 N, 350.35 E)      (-63.47 N,  30.53 E)"
+        print "    11:55 UT, A: ( 52.75 N, 244.64 E)      (-60.94 N, 206.49 E)"
+        print "    02:55 UT, B: ( 64.70 N,  16.63 E)      (-58.19 N,  51.03 E)"
         print ""

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -37,6 +37,9 @@ class rbspFp(object):
         limit FPs loading to L-shell values lesser than this
     apogees_only : Optional[ ]
         record foot-points (usefull if all you want are apogees)
+    force_web_read : Optional[ ]
+        force the information to be read from the JHU/APL website instead of
+        using the Virginia Tech database.  Default is false.
 
     Attributes
     ----------
@@ -83,7 +86,7 @@ class rbspFp(object):
 
     def __init__(self, sTime, eTime=None, spacecraft=None,
                  L_shell_min=None, L_shell_max=None,
-                 apogees_only=False):
+                 apogees_only=False, force_web_read=False):
         from datetime import datetime, timedelta
         from davitpy import rcParams
 
@@ -107,7 +110,10 @@ class rbspFp(object):
 
         # Connect to DB
         isDb = self.__getFpsFromDb()
-        if not isDb:
+
+        if not isDb or force_web_read:
+            logging.info("Information is either not in the database or forcing read from")
+            logging.info("JHU/APL website")
             orbit = self.__getOrbit()
             trace = self.__getTrace(orbit)
             self.scraft = orbit['scraft']

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -526,13 +526,7 @@ class rbspFp(object):
 
         if len(self.apogees) > 0:
             for i in self.apogees:
-                print type(self.times[i])
-                print type(self.scraft[i].upper())
-                print type(self.latNH[i])
-                print type(self.lonNH[i])
-                print type(self.latSH[i])
-                print type(self.lonSH[i])
-                sOut += '\t\t {:%H:%M} UT, { }: ({:6.2f} N, {:6.2f} E)' + \
+                sOut += '\t\t {:%H:%M} UT, {}: ({:6.2f} N, {:6.2f} E)' + \
                 '\t({:6.2f} N, {:6.2f} E)\n'.format(self.times[i], \
                                                     self.scraft[i].upper(), \
                                                     self.latNH[i], \

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -396,7 +396,8 @@ class rbspFp(object):
         import urllib2
         import urllib
         from datetime import datetime
-        import time
+#        import time
+        import calendar
 
         logging.info('Get orbit from JHU/APL')
 
@@ -429,8 +430,8 @@ class rbspFp(object):
                 logging.error('Error in spacecraft name.  ' +
                               'Danger Will Robinson')
             # Convert sTime, eTime to an epoch time
-            sEpoch = time.mktime(self.sTime.timetuple())
-            eEpoch = time.mktime(self.eTime.timetuple())
+            sEpoch = calendar.timegm(self.sTime.timetuple())
+            eEpoch = calendar.timegm(self.eTime.timetuple())
             # Calculate the length od data we want in seconds
             extent = eEpoch - sEpoch
             logging.debug('Looking for {} seconds of data'.format(extent))

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -116,11 +116,11 @@ class rbspFp(object):
             isDb = self.__getFpsFromDb()
 
         if not isDb or force_web_read:
-            logging.info("Information is either not in the database or forcing read from")
-            logging.info("JHU/APL website")
+            logging.info("Information is either not in the database or")
+            logging.info("forcing read from JHU/APL website")
             orbit = self.__getOrbit()
-            trace = self.__getTrace(orbit,force_web_read)
-            
+            trace = self.__getTrace(orbit, force_web_read)
+
             self.scraft = orbit['scraft']
 
     def map(self, hemisphere='north', boundinglat=35,
@@ -537,9 +537,8 @@ class rbspFp(object):
         self.latSH = trace.latSH
 
         # Convert trace.datetime to a numpy.ndarray type
-        trace.datetime = np.asarray(trace.datetime)        
-        # Times when the satellite is at apogee
-#        self.times = trace.datetime[mins]
+        trace.datetime = np.asarray(trace.datetime)
+        # Store all of the datetimes in times
         self.times = trace.datetime
 
         self.apogees = np.where(mins)[0]
@@ -563,13 +562,9 @@ class rbspFp(object):
         sOut += '\t{} points\n'.format(len(self.times))
         sOut += '\t{} apogee(s):\n'.format(len(self.apogees))
 
-#        print self.apogees
-#        print self.times
         if len(self.apogees) > 0:
             # In the future sort apgogees by time?
             for i in self.apogees:
-#                print self.times[i]
-#                print i
                 sOut += '\t\t {:%H:%M} UT, {}: ({:6.2f} N, {:6.2f} E)' \
                     '\t({:6.2f} N, {:6.2f} E)\n'. \
                     format(self.times[i], self.scraft[i].upper(),
@@ -660,7 +655,7 @@ if __name__ == '__main__':
         print "Expected results for orbits on June 2, 2016  between"
         print "00:00 and 12:00 utc:"
         print "    07:45 UT, B: ( 57.82 N, 314.19 E)      (-72.89 N, 351.06 E)"
-        print "    08:45 UT, A: ( 56.43 N, 307.07 E)      (-74.73 N, 337.82 E)"        
+        print "    08:45 UT, A: ( 56.43 N, 307.07 E)      (-74.73 N, 337.82 E)"
         raw_input("Enter to continue on to another example")
 
         print ""

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -13,7 +13,6 @@ rbspFp  FPs reading (or calculating) and plotting
 
 """
 import logging
-import sys
 
 ############################################################################
 # Foot Points (FPs) calculation and plotting
@@ -449,11 +448,6 @@ class rbspFp(object):
                 else:
                     orbit['kind'].append( 'final' )
                 orbit['scraft'].append( sc )
-
-            print "THIS IS THE END OF THE TEST!"
-            sys.exit()
-
-
 
         return orbit
 

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -478,7 +478,8 @@ class rbspFp(object):
         Belongs to class rbspFp
 
         """
-        import tsyganenko as ts
+#        import tsyganenko as ts
+        import davitpy.models.tsyganenko as ts
         import numpy as np
 
         fname = 'trace.{:%Y%m%d}.{:%Y%m%d}.dat'.format(self.sTime, self.eTime)
@@ -525,12 +526,18 @@ class rbspFp(object):
 
         if len(self.apogees) > 0:
             for i in self.apogees:
-                sOut += '\t\t{:%H:%M} UT, {}: ({:6.2f} N, {:6.2f} E)' + \
-                '\t({:6.2f} N, {:6.2f} E)\n'.format(self.times[i],
-                                                    self.scraft[i].upper(),
-                                                    self.latNH[i],
-                                                    self.lonNH[i],
-                                                    self.latSH[i],
+                print type(self.times[i])
+                print type(self.scraft[i].upper())
+                print type(self.latNH[i])
+                print type(self.lonNH[i])
+                print type(self.latSH[i])
+                print type(self.lonSH[i])
+                sOut += '\t\t {:%H:%M} UT, { }: ({:6.2f} N, {:6.2f} E)' + \
+                '\t({:6.2f} N, {:6.2f} E)\n'.format(self.times[i], \
+                                                    self.scraft[i].upper(), \
+                                                    self.latNH[i], \
+                                                    self.lonNH[i], \
+                                                    self.latSH[i], \
                                                     self.lonSH[i])
 
         return sOut
@@ -596,15 +603,29 @@ class rbspFp(object):
         ax.add_artist(ab)
 ############################################################################
 if __name__ == '__main__':
+        # Get all the FPs for 1/Sept/2012 from 0 to 6 UT
+        from datetime import datetime
+        import rbsp
+        sTime = datetime(2012,9,1,0)
+        eTime = datetime(2012,9,1,6)
+        fps = rbsp.rbspFp(sTime, eTime)
+        # Pretty print the apogees in that period
+        print fps
+        # Plot them on a map
+#        fps.map()
+
+
     # Create a test of this code
-    import datetime
-    import davitpy
+#    import datetime
+#    import davitpy
 
 
-    sTime = datetime.datetime(2015, 10, 12, 0, 0)
-    eTime = datetime.datetime(2015, 10, 12, 6, 0)
-    spacecraft = 'a'
+#    sTime = datetime.datetime(2015, 10, 12, 0, 0)
+#    eTime = datetime.datetime(2015, 10, 12, 6, 0)
+#    spacecraft = 'a'
 
-    footprint = rbspFp(sTime, eTime=eTime, spacecraft=spacecraft)
-    orbit = self_getOrbit()
+#    footprint = rbspFp(sTime, eTime=eTime, spacecraft=spacecraft)
+#    orbit = footprint.__getOrbit()
+
+#    print orbit
     

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -171,7 +171,7 @@ class rbspFp(object):
 
         # Generate map and background
         myMap = Basemap(projection=projection, lon_0=270,
-                        boundinglat=sgn*boundinglat, ax=ax)
+                        boundinglat=sgn * boundinglat, ax=ax)
         myMap.fillcontinents(color='.8')
         myMap.drawmeridians(range(0, 360, 20), alpha=0.5)
         myMap.drawparallels(range(-80, 81, 20), alpha=0.5)
@@ -249,7 +249,7 @@ class rbspFp(object):
                 myMap.scatter(x, y, zorder=6, s=20, facecolors='k')
                 if isinstance(x, list):
                     x, y = x[0], y[0]
-                myMap.ax.text(x*1.04, y*0.96, el['code'].upper())
+                myMap.ax.text(x * 1.04, y * 0.96, el['code'].upper())
                 x, y = myMap(el['fov']['lon'], el['fov']['lat'])
                 myMap.plot(x, y, 'g')
 
@@ -344,17 +344,17 @@ class rbspFp(object):
 
         try:
             conn = MongoClient('mongodb://{}:{}@{}/{}'.format(self._db_user,
-                                                              self._db_pswd, 
+                                                              self._db_pswd,
                                                               self._db_host,
                                                               dbName))
 
             dba = conn[dbName]
         except:
-            logging.error('Could not connect to remote DB: ' + sys.exc_info()[0])
+            logging.error('Could not connect to remote DB: ' +
+                          sys.exc_info()[0])
             return False
 
         return dba
-
 
     def __getOrbit(self):
         """Get orbit data from APL
@@ -366,8 +366,8 @@ class rbspFp(object):
         Returns
         -------
         orbit : list of dict
-            The orbit information about each spacecraft requested.  Here the dictionary
-            values are:
+            The orbit information about each spacecraft requested.  Here the
+            dictionary values are:
             date : a datetime object of the year, month, day
             time : a datetime object of the year, month, day, hour, minute
             alt  : a float of the altitude of the spacecraft
@@ -375,14 +375,15 @@ class rbspFp(object):
             lon  : a float of the footprint latitude of the spacecraft
             kind : a string of either a forecasted or final value
             scraft : a string of the spacecraft letter (a or b)
-            
+
 
         Notes
         -----
         Belongs to class rbspFp
 
         """
-        import urllib2, urllib
+        import urllib2
+        import urllib
         from datetime import datetime
         import time
 
@@ -398,7 +399,7 @@ class rbspFp(object):
             scraft = (self._spacecraft)
 
         orbit = {'date': [],
-                 'time': [], 
+                 'time': [],
                  'alt': [],
                  'lat': [],
                  'lon': [],
@@ -414,17 +415,20 @@ class rbspFp(object):
                 webcraft = "RBSP_B"
             else:
                 logging.error('sc is: ' + sc)
-                logging.error('Error in spacecraft name.  Danger Will Robinson')
+                logging.error('Error in spacecraft name.  ' +
+                              'Danger Will Robinson')
             # Convert sTime, eTime to an epoch time
             sEpoch = time.mktime(self.sTime.timetuple())
             eEpoch = time.mktime(self.eTime.timetuple())
             # Calculate the length od data we want in seconds
             extent = eEpoch - sEpoch
 
-            rbspbase = "http://rbspgway.jhuapl.edu/rTools/orbitlist/lib/php/orbitlist.php?cli="
-            # Add on calculated variables. Here the [:-2] drop the last two digits
-            # from the time which are ".0"
-            rbspbase += cmode + "%20" + webcraft + "%20" + str(sEpoch)[:-2] + "%20" + str(extent)[:-2]
+            rbspbase = "http://rbspgway.jhuapl.edu/rTools/orbitlist/lib/php/"
+            rbspbase += "orbitlist.php?cli="
+            # Add on calculated variables. Here the [:-2] drop the last
+            # two digits from the time which are ".0"
+            rbspbase += cmode + "%20" + webcraft + "%20" + str(sEpoch)[:-2]
+            rbspbase += "%20" + str(extent)[:-2]
 
             logging.debug('Looking for new data at: ' + rbspbase)
             f = urllib2.urlopen(rbspbase)
@@ -434,15 +438,17 @@ class rbspFp(object):
             # Close the file
             f.close()
 
-            # Loop through all of the lines in the data we got from the JHU/APL website
-            for i,l in enumerate(out):
-                # Filter the data by the Cadence that we specified earlier, usually every 5 minutes
+            # Loop through all of the lines in the data we got from the
+            # JHU/APL website
+            for i, l in enumerate(out):
+                # Filter the data by the Cadence that we specified earlier,
+                # usually every 5 minutes
                 if i % Cadence != 0:
                     continue
                 # If we've got the right cadence, append the data on here.
                 row = l.split()
                 print l
-                cTime = datetime(int(row[0]), int(row[1]), int(row[2]), 
+                cTime = datetime(int(row[0]), int(row[1]), int(row[2]),
                                  int(row[3]), int(row[4]), int(row[5]))
                 orbit['date'].append(cTime.date())
                 orbit['time'].append(cTime)
@@ -457,14 +463,14 @@ class rbspFp(object):
 
         return orbit
 
-
     def __getTrace(self, data):
         """Trace orbit to the ionosphere
 
         Parameters
         ----------
         data : dict
-            a dictionnary containing ephemeris (with keys 'lat', 'lon', 'alt', 'time')
+            a dictionnary containing ephemeris (with keys 'lat', 'lon', 'alt',
+            'time')
 
         Returns
         -------
@@ -484,8 +490,9 @@ class rbspFp(object):
             logging.info('Read tracing results...')
         except:
             logging.info('Tracing...')
-            trace = ts.tsygTrace(data['lat'], data['lon'], data['alt'], datetime=data['time'], rmin=1.047)
-            trace.save( fname )
+            trace = ts.tsygTrace(data['lat'], data['lon'], data['alt'],
+                                 datetime=data['time'], rmin=1.047)
+            trace.save(fname)
 
         self.lonNH = trace.lonNH
         self.latNH = trace.latNH
@@ -494,10 +501,11 @@ class rbspFp(object):
         self.times = trace.datetime
 
         # Mark apogees
-        mins = np.r_[True, trace.rho[1:] >= trace.rho[:-1]] & np.r_[trace.rho[:-1] > trace.rho[1:], True]
+        mins = np.r_[True, trace.rho[1:] >= trace.rho[:-1]] &
+        np.r_[trace.rho[:-1] > trace.rho[1:], True]
+
         mins[0] = mins[-1] = False
         self.apogees = np.where(mins)[0]
-
 
     def __repr__(self):
         """Output formatting?
@@ -512,20 +520,26 @@ class rbspFp(object):
 
         """
         sOut = 'Van Allen Probes (a.k.a. RBSP) ionospheric footpoints\n'
-        sOut += '{:%Y-%b-%d at %H:%M UT} to {:%Y-%b-%d at %H:%M UT}\n'.format(self.sTime, self.eTime)
+        sOut += '{:%Y-%b-%d at %H:%M UT} to {:%Y-%b-%d at %H:%M UT}\n'.
+        format(self.sTime, self.eTime)
+
         sOut += '\t{} points\n'.format(len(self.times))
         sOut += '\t{} apogee(s):\n'.format(len(self.apogees))
 
         if len(self.apogees) > 0:
             for i in self.apogees:
-                sOut += '\t\t{:%H:%M} UT, {}: ({:6.2f} N, {:6.2f} E)\t({:6.2f} N, {:6.2f} E)\n'.format(self.times[i], self.scraft[i].upper(), 
-                                                                                                self.latNH[i], self.lonNH[i], 
-                                                                                                self.latSH[i], self.lonSH[i])
+                sOut += '\t\t{:%H:%M} UT, {}: ({:6.2f} N, {:6.2f} E)' +
+                '\t({:6.2f} N, {:6.2f} E)\n'.format(self.times[i],
+                                                    self.scraft[i].upper(),
+                                                    self.latNH[i],
+                                                    self.lonNH[i],
+                                                    self.latSH[i],
+                                                    self.lonSH[i])
 
         return sOut
 
-
-    def __textHighlighted(self, xy, text, zorder=None, color='k', fontsize=None):
+    def __textHighlighted(self, xy, text, zorder=None, color='k',
+                          fontsize=None):
         """Plot highlighted annotation (with a white lining)
 
         Parameters
@@ -551,14 +565,17 @@ class rbspFp(object):
 
         ax = gca()
 
-        text_path = mp.text.TextPath( (0,0), text, size=fontsize)
+        text_path = mp.text.TextPath((0, 0), text, size=fontsize)
 
-        p1 = mp.patches.PathPatch(text_path, ec="w", lw=2, fc="w", alpha=0.7, zorder=zorder, 
-                            transform=mp.transforms.IdentityTransform())
-        p2 = mp.patches.PathPatch(text_path, ec="none", fc=color, zorder=zorder, 
-                            transform=mp.transforms.IdentityTransform())
+        p1 = mp.patches.PathPatch(text_path, ec="w", lw=2, fc="w", alpha=0.7,
+                                  zorder=zorder,
+                                  transform=mp.transforms.IdentityTransform())
+        p2 = mp.patches.PathPatch(text_path, ec="none", fc=color,
+                                  zorder=zorder,
+                                  transform=mp.transforms.IdentityTransform())
 
-        offsetbox2 = mp.offsetbox.AuxTransformBox(mp.transforms.IdentityTransform())
+        offsetbox2 = mp.offsetbox.AuxTransformBox(mp.transforms.
+                                                  IdentityTransform())
         offsetbox2.add_artist(p1)
         offsetbox2.add_artist(p2)
 
@@ -566,17 +583,18 @@ class rbspFp(object):
         disp2ax = ax.transAxes.inverted().transform
         data2disp = ax.transData.transform
         disp2data = ax.transData.inverted().transform
-        xyA = disp2ax( data2disp( xy ) )
+        xyA = disp2ax(data2disp(xy))
         frac = 0.5
-        scatC = (-frac*(xyA[0]-0.5)+xyA[0], -frac*(xyA[1]-0.5)+xyA[1])
-        scatC = disp2data( ax2disp( scatC ) )
-        ab = mp.offsetbox.AnnotationBbox( offsetbox2, xy,
-                xybox=(scatC[0], scatC[1]), 
-                boxcoords="data",
-                box_alignment=(.5,.5),
-                arrowprops=dict(arrowstyle="-|>", 
-                facecolor='none'),
-                frameon=False )
+        scatC = (-frac * (xyA[0] - 0.5) + xyA[0],
+                 -frac * (xyA[1] - 0.5) + xyA[1])
+        scatC = disp2data(ax2disp(scatC))
+        ab = mp.offsetbox.AnnotationBbox(offsetbox2, xy,
+                                         xybox=(scatC[0], scatC[1]),
+                                         boxcoords="data",
+                                         box_alignment=(.5, .5),
+                                         arrowprops=dict(arrowstyle="-|>",
+                                                         facecolor='none'),
+                                         frameon=False)
 
         ax.add_artist(ab)
 ############################################################################

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -116,6 +116,7 @@ class rbspFp(object):
             logging.info("JHU/APL website")
             orbit = self.__getOrbit()
             trace = self.__getTrace(orbit)
+            
             self.scraft = orbit['scraft']
 
     def map(self, hemisphere='north', boundinglat=35,
@@ -498,18 +499,32 @@ class rbspFp(object):
                                  datetime=data['time'], rmin=1.047)
             trace.save(fname)
 
-        self.lonNH = trace.lonNH
-        self.latNH = trace.latNH
-        self.lonSH = trace.lonSH
-        self.latSH = trace.latSH
-        self.times = trace.datetime
-
         # Mark apogees
         mins = np.r_[True, trace.rho[1:] >= trace.rho[:-1]] & \
             np.r_[trace.rho[:-1] > trace.rho[1:], True]
 
         mins[0] = mins[-1] = False
-        self.apogees = np.where(mins)[0]
+
+        self.lonNH = trace.lonNH
+        self.latNH = trace.latNH
+        self.lonSH = trace.lonSH
+        self.latSH = trace.latSH
+        # Times when the satellite is at apogee
+        self.time = trace.datetime[mins]
+        ntime = len(self.time)
+
+
+        for i in range(ntime):
+            # Apogee or not
+            if trace.datetime[i] in time:
+                isAp = True
+                self.apogees.append(i)
+            else:
+                False
+            
+        
+
+#        self.apogees = np.where(mins)[0]
 
     def __repr__(self):
         """Output formatting?

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -440,8 +440,10 @@ class rbspFp(object):
             rbspbase += "orbitlist.php?cli="
             # Add on calculated variables. Here the [:-2] drop the last
             # two digits from the time which are ".0"
-            rbspbase += cmode + "%20" + webcraft + "%20" + str(sEpoch)[:-2]
-            rbspbase += "%20" + str(extent)[:-2]
+#            rbspbase += cmode + "%20" + webcraft + "%20" + str(sEpoch)[:-2]
+#            rbspbase += "%20" + str(extent)[:-2]
+            rbspbase += cmode + "%20" + webcraft + "%20" + str(sEpoch)
+            rbspbase += "%20" + str(extent)
 
             logging.debug('Looking for new data at: ' + rbspbase)
             f = urllib2.urlopen(rbspbase)

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -597,29 +597,27 @@ class rbspFp(object):
         ax.add_artist(ab)
 ############################################################################
 if __name__ == '__main__':
+        # Start of a unit test for rbsp.py.  This does not use
+
         # Get all the FPs for 1/Sept/2012 from 0 to 6 UT
         from datetime import datetime
         import rbsp
+
+        print ""
+        print "Testing footprint collection and apogee calculation..."
+        print ""
+        print "Expected results for orbits on September 1, 2012 between"
+        print "00:00 and 06:00 utc:"
+        print "    01:45 UT, A: ( 68.47 N, 94.93 E)     (-51.43 N, 106.23 E)"
+        print "    01:55 UT, B: ( 68.44 N, 92.27 E)     (-51.56 N, 104.03 E)"
+        print ""
+        print "Calculated results:"
+        print ""
         sTime = datetime(2012,9,1,0)
         eTime = datetime(2012,9,1,6)
         fps = rbsp.rbspFp(sTime, eTime)
         # Pretty print the apogees in that period
         print fps
         # Plot them on a map
-#        fps.map()
-
-
-    # Create a test of this code
-#    import datetime
-#    import davitpy
-
-
-#    sTime = datetime.datetime(2015, 10, 12, 0, 0)
-#    eTime = datetime.datetime(2015, 10, 12, 6, 0)
-#    spacecraft = 'a'
-
-#    footprint = rbspFp(sTime, eTime=eTime, spacecraft=spacecraft)
-#    orbit = footprint.__getOrbit()
-
-#    print orbit
+        fps.map()
     

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -488,6 +488,7 @@ class rbspFp(object):
 #        import tsyganenko as ts
         import davitpy.models.tsyganenko as ts
         import numpy as np
+        import datetime
 
         fname = 'trace.{:%Y%m%d}.{:%Y%m%d}.dat'.format(self.sTime, self.eTime)
         try:
@@ -500,8 +501,16 @@ class rbspFp(object):
             trace.save(fname)
 
         # Mark apogees
-        mins = np.r_[True, trace.rho[1:] >= trace.rho[:-1]] & \
-            np.r_[trace.rho[:-1] > trace.rho[1:], True]
+
+#        for rho in trace.rho:
+#            print "loops"
+#            print rho
+        print trace.rho
+
+###### THIS LINE ISN'T WORKING CORRECTLY???? #######
+        mins = np.r_[True, trace.rho[1:] >= trace.rho[:-1]] & np.r_[trace.rho[:-1] > trace.rho[1:], True]
+#        mins = np.r_[True, trace.rho[1:] >= trace.rho[:-1]] & \
+#            np.r_[trace.rho[:-1] > trace.rho[1:], True]
 
         mins[0] = mins[-1] = False
 
@@ -510,6 +519,8 @@ class rbspFp(object):
         self.lonSH = trace.lonSH
         self.latSH = trace.latSH
         # Times when the satellite is at apogee
+        print mins
+        print trace.datetime
         self.time = trace.datetime[mins]
         ntime = len(self.time)
 
@@ -625,16 +636,16 @@ if __name__ == '__main__':
         print ""
         print "Testing footprint collection and apogee calculation..."
         print ""
-        print "Expected results for orbits on September 1, 2012 between"
-        print "00:00 and 06:00 utc:"
-        print "    01:45 UT, A: ( 68.47 N, 94.93 E)     (-51.43 N, 106.23 E)"
-        print "    01:55 UT, B: ( 68.44 N, 92.27 E)     (-51.56 N, 104.03 E)"
-        print ""
+#        print "Expected results for orbits on September 1, 2012 between"
+#        print "00:00 and 06:00 utc:"
+#        print "    01:45 UT, A: ( 68.47 N, 94.93 E)     (-51.43 N, 106.23 E)"
+#        print "    01:55 UT, B: ( 68.44 N, 92.27 E)     (-51.56 N, 104.03 E)"
+#        print ""
         print "Calculated results:"
         print ""
-        sTime = datetime(2012, 9, 1, 0)
-        eTime = datetime(2012, 9, 1, 6)
-        fps = rbsp.rbspFp(sTime, eTime)
+        sTime = datetime(2013, 4, 28, 0)
+        eTime = datetime(2013, 4, 28, 12)
+        fps = rbsp.rbspFp(sTime, eTime, force_web_read=True)
         # Pretty print the apogees in that period
         print fps
         # Plot them on a map

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -500,7 +500,7 @@ class rbspFp(object):
 
         # Mark apogees
         mins = np.r_[True, trace.rho[1:] >= trace.rho[:-1]] & \
-        np.r_[trace.rho[:-1] > trace.rho[1:], True]
+            np.r_[trace.rho[:-1] > trace.rho[1:], True]
 
         mins[0] = mins[-1] = False
         self.apogees = np.where(mins)[0]
@@ -519,7 +519,7 @@ class rbspFp(object):
         """
         sOut = 'Van Allen Probes (a.k.a. RBSP) ionospheric footpoints\n'
         sOut += '{:%Y-%b-%d at %H:%M UT} to {:%Y-%b-%d at %H:%M UT}\n'. \
-        format(self.sTime, self.eTime)
+            format(self.sTime, self.eTime)
 
         sOut += '\t{} points\n'.format(len(self.times))
         sOut += '\t{} apogee(s):\n'.format(len(self.apogees))
@@ -527,12 +527,10 @@ class rbspFp(object):
         if len(self.apogees) > 0:
             for i in self.apogees:
                 sOut += '\t\t {:%H:%M} UT, {}: ({:6.2f} N, {:6.2f} E)' \
-                '\t({:6.2f} N, {:6.2f} E)\n'.format(self.times[i], \
-                                                    self.scraft[i].upper(), \
-                                                    self.latNH[i], \
-                                                    self.lonNH[i], \
-                                                    self.latSH[i], \
-                                                    self.lonSH[i])
+                    '\t({:6.2f} N, {:6.2f} E)\n'. \
+                    format(self.times[i], self.scraft[i].upper(),
+                           self.latNH[i], self.lonNH[i], self.latSH[i],
+                           self.lonSH[i])
 
         return sOut
 
@@ -613,11 +611,10 @@ if __name__ == '__main__':
         print ""
         print "Calculated results:"
         print ""
-        sTime = datetime(2012,9,1,0)
-        eTime = datetime(2012,9,1,6)
+        sTime = datetime(2012, 9, 1, 0)
+        eTime = datetime(2012, 9, 1, 6)
         fps = rbsp.rbspFp(sTime, eTime)
         # Pretty print the apogees in that period
         print fps
         # Plot them on a map
         fps.map()
-    

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -598,3 +598,16 @@ class rbspFp(object):
 
         ax.add_artist(ab)
 ############################################################################
+if __name__ == '__main__':
+    # Create a test of this code
+    import datetime
+    import davitpy
+
+
+    sTime = datetime.datetime(2015, 10, 12, 0, 0)
+    eTime = datetime.datetime(2015, 10, 12, 6, 0)
+    spacecraft = 'a'
+
+    footprint = rbspFp(sTime, eTime=eTime, spacecraft=spacecraft)
+    orbit = self_getOrbit()
+    

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -383,7 +383,6 @@ class rbspFp(object):
 
         logging.info('Get orbit from JHU/APL')
 
-        header = 'on'
         cmode = 'geo'
         Cadence = 5
 

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -445,7 +445,6 @@ class rbspFp(object):
                     continue
                 # If we've got the right cadence, append the data on here.
                 row = l.split()
-                print l
                 cTime = datetime(int(row[0]), int(row[1]), int(row[2]),
                                  int(row[3]), int(row[4]), int(row[5]))
                 orbit['date'].append(cTime.date())

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -90,6 +90,9 @@ class rbspFp(object):
         from datetime import datetime, timedelta
         from davitpy import rcParams
 
+        # Initialize to false so that it's set true later
+        isDb = False
+
         # Check inputs
         assert(spacecraft is None or spacecraft == 'a' or spacecraft == 'b'), \
             logging.error('spacecraft must be a, b, or None')
@@ -109,7 +112,8 @@ class rbspFp(object):
         self._apogees_only = apogees_only
 
         # Connect to DB
-        isDb = self.__getFpsFromDb()
+        if not force_web_read:
+            isDb = self.__getFpsFromDb()
 
         if not isDb or force_web_read:
             logging.info("Information is either not in the database or forcing read from")
@@ -326,6 +330,8 @@ class rbspFp(object):
         self.apogees = np.array(self.apogees)
         self.L = np.array(self.L)
 
+#        print self.times
+
         return True
 
     def __dbConnect(self, dbName):
@@ -519,7 +525,8 @@ class rbspFp(object):
         # Convert trace.datetime to a numpy.ndarray type
         trace.datetime = np.asarray(trace.datetime)        
         # Times when the satellite is at apogee
-        self.times = trace.datetime[mins]
+#        self.times = trace.datetime[mins]
+        self.times = trace.datetime
 
         self.apogees = np.where(mins)[0]
 
@@ -542,8 +549,12 @@ class rbspFp(object):
         sOut += '\t{} points\n'.format(len(self.times))
         sOut += '\t{} apogee(s):\n'.format(len(self.apogees))
 
+#        print self.apogees
+#        print self.times
         if len(self.apogees) > 0:
-            for i in range(len(self.apogees)):
+            for i in self.apogees:
+#                print self.times[i]
+#                print i
                 sOut += '\t\t {:%H:%M} UT, {}: ({:6.2f} N, {:6.2f} E)' \
                     '\t({:6.2f} N, {:6.2f} E)\n'. \
                     format(self.times[i], self.scraft[i].upper(),
@@ -622,17 +633,17 @@ if __name__ == '__main__':
         print ""
         print "Testing footprint collection and apogee calculation..."
         print ""
-        print "Calculated results:"
-        print ""
-        sTime = datetime(2016, 6, 28, 0)
-        eTime = datetime(2016, 6, 28, 12)
+        sTime = datetime(2016, 6, 30, 0)
+        eTime = datetime(2016, 6, 30, 12)
         fps = rbsp.rbspFp(sTime, eTime, force_web_read=True)
 #        fps = rbsp.rbspFp(sTime, eTime)
         print ""
-        print "Expected results for orbits on July 1, 2016 between"
-        print "00:00 and 12:00 utc:"
-        print "    01:45 UT, A: ( 68.47 N, 94.93 E)     (-51.43 N, 106.23 E)"
-        print "    01:55 UT, B: ( 68.44 N, 92.27 E)     (-51.56 N, 104.03 E)"
+        print "Calculated results:"
         print ""
         # Pretty print the apogees in that period
         print fps
+#        print "Expected results for orbits on  between"
+#        print "00:00 and 12:00 utc:"
+#        print "    01:45 UT, A: ( 68.47 N, 94.93 E)     (-51.43 N, 106.23 E)"
+#        print "    01:55 UT, B: ( 68.44 N, 92.27 E)     (-51.56 N, 104.03 E)"
+        print ""

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -500,17 +500,13 @@ class rbspFp(object):
                                  datetime=data['time'], rmin=1.047)
             trace.save(fname)
 
+
+        # Convert trace.rho to a numpy.ndarray type
+        trace.rho = np.asarray(trace.rho)
+
         # Mark apogees
-
-#        for rho in trace.rho:
-#            print "loops"
-#            print rho
-        print trace.rho
-
-###### THIS LINE ISN'T WORKING CORRECTLY???? #######
-        mins = np.r_[True, trace.rho[1:] >= trace.rho[:-1]] & np.r_[trace.rho[:-1] > trace.rho[1:], True]
-#        mins = np.r_[True, trace.rho[1:] >= trace.rho[:-1]] & \
-#            np.r_[trace.rho[:-1] > trace.rho[1:], True]
+        mins = np.r_[True, trace.rho[1:] >= trace.rho[:-1]] & \
+            np.r_[trace.rho[:-1] > trace.rho[1:], True]
 
         mins[0] = mins[-1] = False
 
@@ -518,24 +514,13 @@ class rbspFp(object):
         self.latNH = trace.latNH
         self.lonSH = trace.lonSH
         self.latSH = trace.latSH
+
+        # Convert trace.datetime to a numpy.ndarray type
+        trace.datetime = np.asarray(trace.datetime)        
         # Times when the satellite is at apogee
-        print mins
-        print trace.datetime
-        self.time = trace.datetime[mins]
-        ntime = len(self.time)
+        self.times = trace.datetime[mins]
 
-
-        for i in range(ntime):
-            # Apogee or not
-            if trace.datetime[i] in time:
-                isAp = True
-                self.apogees.append(i)
-            else:
-                False
-            
-        
-
-#        self.apogees = np.where(mins)[0]
+        self.apogees = np.where(mins)[0]
 
     def __repr__(self):
         """Output formatting?
@@ -557,7 +542,7 @@ class rbspFp(object):
         sOut += '\t{} apogee(s):\n'.format(len(self.apogees))
 
         if len(self.apogees) > 0:
-            for i in self.apogees:
+            for i in range(len(self.apogees)):
                 sOut += '\t\t {:%H:%M} UT, {}: ({:6.2f} N, {:6.2f} E)' \
                     '\t({:6.2f} N, {:6.2f} E)\n'. \
                     format(self.times[i], self.scraft[i].upper(),
@@ -641,11 +626,12 @@ if __name__ == '__main__':
 #        print "    01:45 UT, A: ( 68.47 N, 94.93 E)     (-51.43 N, 106.23 E)"
 #        print "    01:55 UT, B: ( 68.44 N, 92.27 E)     (-51.56 N, 104.03 E)"
 #        print ""
-        print "Calculated results:"
-        print ""
-        sTime = datetime(2013, 4, 28, 0)
-        eTime = datetime(2013, 4, 28, 12)
-        fps = rbsp.rbspFp(sTime, eTime, force_web_read=True)
+#        print "Calculated results:"
+#        print ""
+        sTime = datetime(2016, 7, 1, 0)
+        eTime = datetime(2016, 7, 1, 12)
+#        fps = rbsp.rbspFp(sTime, eTime, force_web_read=True)
+        fps = rbsp.rbspFp(sTime, eTime)
         # Pretty print the apogees in that period
         print fps
         # Plot them on a map

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -105,8 +105,6 @@ class rbspFp(object):
         self.L_shell_max = L_shell_max
         self._apogees_only = apogees_only
 
-        orbit = self.__getOrbit()
-
         # Connect to DB
         isDb = self.__getFpsFromDb()
         if not isDb:

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -499,7 +499,7 @@ class rbspFp(object):
         self.times = trace.datetime
 
         # Mark apogees
-        mins = np.r_[True, trace.rho[1:] >= trace.rho[:-1]] &
+        mins = np.r_[True, trace.rho[1:] >= trace.rho[:-1]] & \
         np.r_[trace.rho[:-1] > trace.rho[1:], True]
 
         mins[0] = mins[-1] = False
@@ -518,7 +518,7 @@ class rbspFp(object):
 
         """
         sOut = 'Van Allen Probes (a.k.a. RBSP) ionospheric footpoints\n'
-        sOut += '{:%Y-%b-%d at %H:%M UT} to {:%Y-%b-%d at %H:%M UT}\n'.
+        sOut += '{:%Y-%b-%d at %H:%M UT} to {:%Y-%b-%d at %H:%M UT}\n'. \
         format(self.sTime, self.eTime)
 
         sOut += '\t{} points\n'.format(len(self.times))
@@ -526,7 +526,7 @@ class rbspFp(object):
 
         if len(self.apogees) > 0:
             for i in self.apogees:
-                sOut += '\t\t{:%H:%M} UT, {}: ({:6.2f} N, {:6.2f} E)' +
+                sOut += '\t\t{:%H:%M} UT, {}: ({:6.2f} N, {:6.2f} E)' + \
                 '\t({:6.2f} N, {:6.2f} E)\n'.format(self.times[i],
                                                     self.scraft[i].upper(),
                                                     self.latNH[i],

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -526,7 +526,7 @@ class rbspFp(object):
 
         if len(self.apogees) > 0:
             for i in self.apogees:
-                sOut += '\t\t {:%H:%M} UT, {}: ({:6.2f} N, {:6.2f} E)' + \
+                sOut += '\t\t {:%H:%M} UT, {}: ({:6.2f} N, {:6.2f} E)' \
                 '\t({:6.2f} N, {:6.2f} E)\n'.format(self.times[i], \
                                                     self.scraft[i].upper(), \
                                                     self.latNH[i], \

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -427,6 +427,7 @@ class rbspFp(object):
             eEpoch = time.mktime(self.eTime.timetuple())
             # Calculate the length od data we want in seconds
             extent = eEpoch - sEpoch
+            logging.debug('Looking for {} seconds of data'.format(extent))
 
             rbspbase = "http://rbspgway.jhuapl.edu/rTools/orbitlist/lib/php/"
             rbspbase += "orbitlist.php?cli="
@@ -621,18 +622,17 @@ if __name__ == '__main__':
         print ""
         print "Testing footprint collection and apogee calculation..."
         print ""
-#        print "Expected results for orbits on September 1, 2012 between"
-#        print "00:00 and 06:00 utc:"
-#        print "    01:45 UT, A: ( 68.47 N, 94.93 E)     (-51.43 N, 106.23 E)"
-#        print "    01:55 UT, B: ( 68.44 N, 92.27 E)     (-51.56 N, 104.03 E)"
-#        print ""
-#        print "Calculated results:"
-#        print ""
-        sTime = datetime(2016, 7, 1, 0)
-        eTime = datetime(2016, 7, 1, 12)
-#        fps = rbsp.rbspFp(sTime, eTime, force_web_read=True)
-        fps = rbsp.rbspFp(sTime, eTime)
+        print "Calculated results:"
+        print ""
+        sTime = datetime(2016, 6, 28, 0)
+        eTime = datetime(2016, 6, 28, 12)
+        fps = rbsp.rbspFp(sTime, eTime, force_web_read=True)
+#        fps = rbsp.rbspFp(sTime, eTime)
+        print ""
+        print "Expected results for orbits on July 1, 2016 between"
+        print "00:00 and 12:00 utc:"
+        print "    01:45 UT, A: ( 68.47 N, 94.93 E)     (-51.43 N, 106.23 E)"
+        print "    01:55 UT, B: ( 68.44 N, 92.27 E)     (-51.56 N, 104.03 E)"
+        print ""
         # Pretty print the apogees in that period
         print fps
-        # Plot them on a map
-        fps.map()

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -366,6 +366,7 @@ class rbspFp(object):
         """
         import urllib2, urllib
         from datetime import datetime
+        import time
 
         logging.info('Get orbit from JHU/APL')
 
@@ -386,25 +387,50 @@ class rbspFp(object):
                 'scraft': []}
         for sc in scraft:
             logging.info('Get orbit of spacecraft {} from APL'.format(sc))
+            # Convert input spacecraft to what the URL will want to see
+            if sc == 'a':
+                webcraft = "RBSP_A"
+            elif sc == 'b':
+                webcraft = "RBSP_B"
+            else:
+                logging.error('sc is: ' + sc)
+                logging.error('Error in spacecraft name.  Danger Will Robinson')
+            # Convert sTime, eTime to an epoch time
+            sEpoch = time.mktime(sTime.timetuple())
+            eEpoch = time.mktime(eTime.timetuple())
+            # Calculate the length od data we want in seconds
+            extent = eEpoch - sEpoch
 
-            params = urllib.urlencode({'sDay': str( self.sTime.day ),
-                                        'sMonth': str( self.sTime.month ),
-                                        'sYear': str( self.sTime.year ),
-                                        'sHour': str( self.sTime.hour ),
-                                        'sMinute': str( self.sTime.minute ),
-                                        'eDay': str( self.eTime.day ),
-                                        'eMonth': str( self.eTime.month ),
-                                        'eYear': str( self.eTime.year ),
-                                        'eHour': str( self.eTime.hour ),
-                                        'eMinute': str( self.eTime.minute ),
-                                        'Cadence': str( Cadence ),
-                                        'mode': str( cmode ),
-                                        'scraft': sc,
-                                        'header': header,
-                                        'getASCII': 'Get ASCII Output'})
-            f = urllib2.urlopen("http://athena.jhuapl.edu/LT_Position_Calc", params)
+#            params = urllib.urlencode({'sDay': str( self.sTime.day ),
+#                                        'sMonth': str( self.sTime.month ),
+#                                        'sYear': str( self.sTime.year ),
+#                                        'sHour': str( self.sTime.hour ),
+#                                        'sMinute': str( self.sTime.minute ),
+#                                        'eDay': str( self.eTime.day ),
+#                                        'eMonth': str( self.eTime.month ),
+#                                        'eYear': str( self.eTime.year ),
+#                                        'eHour': str( self.eTime.hour ),
+#                                        'eMinute': str( self.eTime.minute ),
+#                                        'Cadence': str( Cadence ),
+#                                        'mode': str( cmode ),
+#                                        'scraft': sc,
+#                                        'header': header,
+#                                        'getASCII': 'Get ASCII Output'})
+#            f = urllib2.urlopen("http://athena.jhuapl.edu/LT_Position_Calc", params)
             # f = urllib2.urlopen("http://athena.jhuapl.edu/orbit_pos", params)
+            rbspbase = "http://rbspgway.jhuapl.edu/rTools/orbitlist/lib/php/orbitlist.php?cli="
+            # Add on calculated variables. Here the [:-2] drop the last two digits
+            # from the time which are ".0"
+            rbspbase += cmode + "%20" + webcraft + "%20" + str(sEpoch)[:-2] + "%20" + str(extent)[:-2]
+
+            logging.debug('Looking for new data at: ' + rbspbase)
+            f = urllib2.urlopen(rbspbase)
+
             out = f.read().splitlines()
+            for line in out:
+                print line
+            print "THIS IS THE END OF THE TEST!"
+            sys.exit()
             f.close()
 
             st = out.index('<pre>')+1

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -27,7 +27,8 @@ class rbspFp(object):
     eTime : Optional[ ]
         end date/time to get FPs (defaulst to 24 hours after `sTime`)
     spacecraft : Optional[ ]
-        limit FPs loading to a specific spacecraft
+        limit FPs loading to a specific spacecraft, a or b.  If None, then both
+        spacecraft will be loaded.
     L_shell_min :
         limit FPs loading to L-shell values greater than this
     L_shell_max : Optional[ ]
@@ -82,6 +83,11 @@ class rbspFp(object):
         apogees_only=False):
         from datetime import datetime, timedelta
         from davitpy import rcParams
+
+        # Check inputs
+        assert(spacecraft is None or spacecraft == 'a'
+               or spacecraft == 'b'), \
+            logging.error('spacecraft must be a, b, or None')
 
         # MongoDB server
         self._db_user = rcParams['SDBREADUSER']
@@ -379,6 +385,8 @@ class rbspFp(object):
                 'lon': [],
                 'scraft': []}
         for sc in scraft:
+            logging.info('Get orbit of spacecraft {} from APL'.format(sc))
+
             params = urllib.urlencode({'sDay': str( self.sTime.day ),
                                         'sMonth': str( self.sTime.month ),
                                         'sYear': str( self.sTime.year ),

--- a/davitpy/gme/sat/rbsp.py
+++ b/davitpy/gme/sat/rbsp.py
@@ -14,11 +14,13 @@ rbspFp  FPs reading (or calculating) and plotting
 """
 import logging
 
+
 ############################################################################
 # Foot Points (FPs) calculation and plotting
 ############################################################################
 class rbspFp(object):
-    """This class reads FPs from the SuperDARN FPs database, or generate them if necessary
+    """This class reads FPs from the SuperDARN FPs database, or generate them
+    if necessary
 
     Parameters
     ----------
@@ -51,12 +53,12 @@ class rbspFp(object):
 
     Methods
     -------
-    map(hemisphere='north', boundinglat=35, spacecraft=None, legend=True, date=True, 
-        apogees=False)
+    map(hemisphere='north', boundinglat=35, spacecraft=None, legend=True,
+        date=True, apogees=False)
         Plot footpoints on a map
     showISR(myMap, isr)
         Overlay incoherent-scatter radar field-of-views on map
-    
+
     Example
     -------
         # Get all the FPs for 1/Sept/2012 from 0 to 6 UT
@@ -72,21 +74,21 @@ class rbspFp(object):
 
     Notes
     -----
-    Try not to request more than 24 hours at once, unless all you want are apogees.
+    Try not to request more than 24 hours at once, unless all you want are
+    apogees.
 
     written by Sebastien de Larquier, 2013-03
 
     """
 
-    def __init__(self, sTime, eTime=None, spacecraft=None, 
-        L_shell_min=None, L_shell_max=None,  
-        apogees_only=False):
+    def __init__(self, sTime, eTime=None, spacecraft=None,
+                 L_shell_min=None, L_shell_max=None,
+                 apogees_only=False):
         from datetime import datetime, timedelta
         from davitpy import rcParams
 
         # Check inputs
-        assert(spacecraft is None or spacecraft == 'a'
-               or spacecraft == 'b'), \
+        assert(spacecraft is None or spacecraft == 'a' or spacecraft == 'b'), \
             logging.error('spacecraft must be a, b, or None')
 
         # MongoDB server
@@ -98,7 +100,7 @@ class rbspFp(object):
         # Input
         self.sTime = sTime
         self.eTime = eTime if eTime else sTime + timedelta(hours=24)
-        self._spacecraft = spacecraft.lower() if spacecraft else ['a','b']
+        self._spacecraft = spacecraft.lower() if spacecraft else ['a', 'b']
         self.L_shell_min = L_shell_min
         self.L_shell_max = L_shell_max
         self._apogees_only = apogees_only
@@ -112,10 +114,9 @@ class rbspFp(object):
             trace = self.__getTrace(orbit)
             self.scraft = orbit['scraft']
 
-
-    def map(self, hemisphere='north', boundinglat=35, 
-        spacecraft=None, legend=True, date=True, 
-        apogees=False):
+    def map(self, hemisphere='north', boundinglat=35,
+            spacecraft=None, legend=True, date=True,
+            apogees=False):
         """Plot FPs on a map
 
         Parameters
@@ -169,44 +170,47 @@ class rbspFp(object):
             lon = self.lonSH
 
         # Generate map and background
-        myMap = Basemap(projection=projection, lon_0=270, boundinglat=sgn*boundinglat, ax=ax)
+        myMap = Basemap(projection=projection, lon_0=270,
+                        boundinglat=sgn*boundinglat, ax=ax)
         myMap.fillcontinents(color='.8')
-        myMap.drawmeridians(range(0,360,20), alpha=0.5)
-        myMap.drawparallels(range(-80,81,20), alpha=0.5)
+        myMap.drawmeridians(range(0, 360, 20), alpha=0.5)
+        myMap.drawparallels(range(-80, 81, 20), alpha=0.5)
         # Calculate FP coordinates
         x, y = myMap(lon, lat)
         # Scatter FPs
         if spacecraft is None or spacecraft == 'a':
-            myMap.scatter(x[self.scraft == 'a'], y[self.scraft == 'a'], 
-                zorder=5, edgecolors='none', s=10, facecolors='r', 
-                alpha=.8)
+            myMap.scatter(x[self.scraft == 'a'], y[self.scraft == 'a'],
+                          zorder=5, edgecolors='none', s=10, facecolors='r',
+                          alpha=.8)
             if legend:
-                ax.text(0, -0.01, 'RBSP-A', transform=ax.transAxes, 
-                    color='r', ha='left', va='top')
+                ax.text(0, -0.01, 'RBSP-A', transform=ax.transAxes,
+                        color='r', ha='left', va='top')
         if spacecraft is None or spacecraft == 'b':
-            myMap.scatter(x[self.scraft == 'b'], y[self.scraft == 'b'], 
-                zorder=5, edgecolors='none', s=10, facecolors='b', 
-                alpha=.8)
+            myMap.scatter(x[self.scraft == 'b'], y[self.scraft == 'b'],
+                          zorder=5, edgecolors='none', s=10, facecolors='b',
+                          alpha=.8)
             if legend:
-                ax.text(1, -0.01, 'RBSP-B', transform=ax.transAxes, 
-                    color='b', ha='right', va='top')
+                ax.text(1, -0.01, 'RBSP-B', transform=ax.transAxes,
+                        color='b', ha='right', va='top')
         # Show date/time interval
         if date:
             if self.sTime.date() == self.eTime.date():
                 dateTitle = '{:%d/%b/%Y %H:%M UT} - {:%H:%M UT}'
             elif self.sTime.time() == self.eTime.time():
                 dateTitle = '{:%d/%b/%Y} - {:%d/%b/%Y (%H:%M UT)}'
-            else: dateTitle = '{:%d/%b/%Y %H:%M UT} - {:%d/%b/%Y %H:%M UT}'
-            ax.text(0, 1.01, dateTitle.format(self.sTime, self.eTime), transform=ax.transAxes)
+            else:
+                dateTitle = '{:%d/%b/%Y %H:%M UT} - {:%d/%b/%Y %H:%M UT}'
+            ax.text(0, 1.01, dateTitle.format(self.sTime, self.eTime),
+                    transform=ax.transAxes)
 
         if apogees:
-            myMap.scatter(x[self.apogees], y[self.apogees], 
-                zorder=5, edgecolors='w', s=10, facecolors='k')
+            myMap.scatter(x[self.apogees], y[self.apogees],
+                          zorder=5, edgecolors='w', s=10, facecolors='k')
             for ap in self.apogees:
-                self.__textHighlighted((x[ap],y[ap]), '{:%H:%M}'.format(self.times[ap]))
+                self.__textHighlighted((x[ap], y[ap]),
+                                       '{:%H:%M}'.format(self.times[ap]))
 
         return myMap
-
 
     def showISR(self, myMap, isr):
         """overlay ISR fovs on map
@@ -216,7 +220,8 @@ class rbspFp(object):
         myMap : Basemap
 
         isr : list or str
-            a list of ISRs to be plotted (codes include mho, sdt, eiscat, pfisr, risr)
+            a list of ISRs to be plotted (codes include mho, sdt, eiscat,
+            pfisr, risr)
 
         Notes
         -----
@@ -227,25 +232,26 @@ class rbspFp(object):
 
         for rad in isr:
             dbConn = self.__dbConnect('isr')
-            if not dbConn: 
+            if not dbConn:
                 logging.error('Could not access DB')
                 return
 
             qIn = {'code': rad}
             qRes = dbConn.info.find(qIn)
-            if qRes.count() == 0: 
+            if qRes.count() == 0:
                 logging.warning('Radar {} not found in db'.format(rad))
-                logging.warning('Use one or more in {}'.format(dbConn.codes.find_one()['codes']))
+                logging.warning('Use one or more in {}'.
+                                format(dbConn.codes.find_one()['codes']))
                 continue
 
             for el in qRes:
                 x, y = myMap(el['pos']['lon'], el['pos']['lat'])
                 myMap.scatter(x, y, zorder=6, s=20, facecolors='k')
-                if isinstance(x, list): x, y = x[0], y[0]
+                if isinstance(x, list):
+                    x, y = x[0], y[0]
                 myMap.ax.text(x*1.04, y*0.96, el['code'].upper())
                 x, y = myMap(el['fov']['lon'], el['fov']['lat'])
                 myMap.plot(x, y, 'g')
-
 
     def __getFpsFromDb(self):
         """Get FPs from DB
@@ -267,6 +273,7 @@ class rbspFp(object):
         import numpy as np
 
         dbConn = self.__dbConnect(self._db_name)
+
         if not dbConn: return False
 
         isAp = True if self._apogees_only else None
@@ -297,14 +304,14 @@ class rbspFp(object):
         self.apogees = []
         self.L = []
         for i, el in enumerate(qRes):
-            self.lonNH.append( el['lonNH'] )
-            self.latNH.append( el['latNH'] )
-            self.lonSH.append( el['lonSH'] )
-            self.latSH.append( el['latSH'] )
-            self.times.append( el['time'] )
-            self.scraft.append( el['scraft'] )
-            self.L.append( el['L'] )
-            if el['isApogee']: self.apogees.append( i )
+            self.lonNH.append(el['lonNH'])
+            self.latNH.append(el['latNH'])
+            self.lonSH.append(el['lonSH'])
+            self.latSH.append(el['latSH'])
+            self.times.append(el['time'])
+            self.scraft.append(el['scraft'])
+            self.L.append(el['L'])
+            if el['isApogee']: self.apogees.append(i)
         self.lonNH = np.array(self.lonNH)
         self.latNH = np.array(self.latNH)
         self.lonSH = np.array(self.lonSH)
@@ -315,7 +322,6 @@ class rbspFp(object):
         self.L = np.array(self.L)
 
         return True
-
 
     def __dbConnect(self, dbName):
         """Try to establish a connection to remote db database
@@ -337,10 +343,10 @@ class rbspFp(object):
         import sys
 
         try:
-            conn = MongoClient( 'mongodb://{}:{}@{}/{}'.format(self._db_user,
-                                                            self._db_pswd, 
-                                                            self._db_host,
-                                                            dbName) )
+            conn = MongoClient('mongodb://{}:{}@{}/{}'.format(self._db_user,
+                                                              self._db_pswd, 
+                                                              self._db_host,
+                                                              dbName))
 
             dba = conn[dbName]
         except:
@@ -436,18 +442,18 @@ class rbspFp(object):
                 # If we've got the right cadence, append the data on here.
                 row = l.split()
                 print l
-                cTime = datetime(	int(row[0]), int(row[1]), int(row[2]), 
-                                    int(row[3]), int(row[4]), int(row[5])	)
-                orbit['date'].append( cTime.date() )
-                orbit['time'].append( cTime )
-                orbit['alt'].append( float(row[6]) )
-                orbit['lat'].append( float(row[7]) )
-                orbit['lon'].append( float(row[8]) )
+                cTime = datetime(int(row[0]), int(row[1]), int(row[2]), 
+                                 int(row[3]), int(row[4]), int(row[5]))
+                orbit['date'].append(cTime.date())
+                orbit['time'].append(cTime)
+                orbit['alt'].append(float(row[6]))
+                orbit['lat'].append(float(row[7]))
+                orbit['lon'].append(float(row[8]))
                 if cTime > datetime.utcnow():
-                    orbit['kind'].append( 'forecast' )
+                    orbit['kind'].append('forecast')
                 else:
-                    orbit['kind'].append( 'final' )
-                orbit['scraft'].append( sc )
+                    orbit['kind'].append('final')
+                orbit['scraft'].append(sc)
 
         return orbit
 


### PR DESCRIPTION
Found the website information for accessing Van Allen probe orbit data outdated in #209. This pull request fixes this bug by updating the URL as well as adjusting to the new returned data format from the JHU/APL server.

You can confirm that the old URL does not work by using:

```
# Get all the FPs for 2/Jul/2016 from 0 to 12 UT
from datetime import datetime
import rbsp

    print ""
    print "Testing footprint collection and apogee calculation..."
    print ""
    print "Expected results for orbits on July 2, 2012 between"
    print "00:00 and 12:00 utc:"
    print "    01:45 UT, A: ( 68.47 N, 94.93 E)     (-51.43 N, 106.23 E)"
    print "    01:55 UT, B: ( 68.44 N, 92.27 E)     (-51.56 N, 104.03 E)"
    print ""
    print "Calculated results:"
    print ""
    sTime = datetime(2016, 7, 2, 0)
    eTime = datetime(2016, 7, 2, 12)
    fps = rbsp.rbspFp(sTime, eTime)
    # Pretty print the apogees in that period
    print fps
```

I figured out what was going on before.  Before I had an example way in the past which the code goes and accesses a database we generate at VT.  So, I've set the date here to go out in the future which we haven't written values to the database.

On the master/develop branch, I expect you'll get a "connection timed out" type of error.  On the proposed branch here, it should work fairly well.  I've also added a 'force_web_read' parameter that can be set to force the code to re-read the data from the JHU/APL website instead of relying on the VT database.

Also added in a unit test for the module to hopefully start conforming to a file being able to test itself. The code above is largely the unit test for the file, so when using this branch, you can just run `python rbsp.py` in that directory.

I'm thinking I've got this somewhat down now, but please test away!