### PR TITLE
Fixed typo that caused overlayFov to break.

### DIFF
--- a/davitpy/utils/plotUtils.py
+++ b/davitpy/utils/plotUtils.py
@@ -141,6 +141,7 @@ class mapObj(basemap.Basemap):
         import math
         from copy import deepcopy
         import datetime as dt
+        from matplotlib import pyplot
 
         from davitpy.utils import coord_conv, get_coord_dict
 
@@ -192,12 +193,12 @@ class mapObj(basemap.Basemap):
 
         # Initialize map with original Basemap
         super(mapObj, self).__init__(projection=projection,
-                                     resolution=resolution, lat_0=self.lat_0,
-                                     lon_0=self.lon_0, width=width,
-                                     height=height, **kwargs)
+                                     resolution=resolution,lat_0=self.lat_0,
+                                     lon_0=self.lon_0,width=width,
+                                     height=height,ax=ax,**kwargs)
 
-        if ax is not None:
-            self.ax = ax
+        if self.ax is None:
+            self.ax = pyplot.gca()
 
         if draw:
           self.draw()

--- a/davitpy/utils/plotUtils.py
+++ b/davitpy/utils/plotUtils.py
@@ -197,7 +197,7 @@ class mapObj(basemap.Basemap):
                                      height=height, **kwargs)
 
         if ax is not None:
-            mapObj.ax = ax
+            self.ax = ax
 
         if draw:
           self.draw()


### PR DESCRIPTION
As discussed in https://github.com/vtsuperdarn/davitpy/issues/227, there seems to have been a typo in the refactoring or whatever of the plotUtils.mapObj class. This typo breaks some other plotting functionality, such as overlayFov as mentioned in 227.

This is a hotfix branch because it fixes a bug that breaks basic plotting functionality.

To test this pull request, run this code (which will fail without this fix):


    import matplotlib.pyplot as plt
    import datetime
    import davitpy.utils
    from davitpy.pydarn.plotting import *
    
    fig=plt.figure()
    SDate=datetime.datetime(2014,7,8,1,15,9)
     
    #the map Object
    mObj=utils.plotUtils.mapObj(datetime=SDate,lon_0=-80,lat_0=70,showCoords='True',gridLabels='True',grid='True',height=111E3*40,width    =111E3*40)
    mObj.nightshade(SDate,alpha=0.2)
    overlayRadar(mObj,codes='sas',fontSize=12)
    overlayFov(mObj,maxGate=75,beams=[1,2,3,4,5,6,7,8,9,10,11,12,13],codes='sas',lineWidth=2,beamsColors=['green','green','green','green','green','green','green','green','green','green','green','green','green'])


After this pull request is merged into master, it should be merged into develop too.