### PR TITLE
Bugfix sd data types rc params

### DIFF
--- a/davitpy/pydarn/sdio/sdDataTypes.py
+++ b/davitpy/pydarn/sdio/sdDataTypes.py
@@ -42,7 +42,7 @@ class sdDataPtr():
 
     Parameters
     ----------
-    sTime : Optional[datetime]
+    sTime : datetime
         start time of the request
     hemi : str
         hemisphere of data interested in

--- a/davitpy/pydarn/sdio/sdDataTypes.py
+++ b/davitpy/pydarn/sdio/sdDataTypes.py
@@ -40,16 +40,64 @@ alpha = ['a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q',
 class sdDataPtr():
     """A class which contains a pipeline to a data source
 
+    Parameters
+    ----------
+    sTime : Optional[datetime]
+        start time of the request
+    hemi : str
+        hemisphere of data interested in
+    eTime : Optional[datetime]
+        end time of the request
+    src : Optional[str]
+        source of files: local of sftp
+    fileName : Optional[str]
+        name of the file opened
+    fileType : str
+        the type of file: 'grd', 'grdex', 'map', or 'mapex'
+    noCache : Optional[bool]
+        true to not use cached files, regenerate tmp files
+    local_dirfmt : Optional[str]
+        format of the local directory structure. Default: rcParams'
+        'DAVIT_SD_LOCAL_DIRFORMAT' value.
+    local_fnamefmt : Optional[str]
+        format of the local filenames.  Default: rcParams'
+        'DAVIT_SD_LOCAL_FNAMEFMT' value.
+    local_dict : Optional[dict]
+        dictionary of the hemisphere and file type. Default: use
+        the values given for hemi and fileType.
+    remote_dirfmt : Optional[str]
+        format of the remote directory structure.  Default: rcParams'
+        'DAVIT_SD_REMOTE_DIRFORMAT' value.
+    remote_fnamefmt : Optional[str]
+        format of the remote filenames.  Default: rcParams'
+        'DAVIT_SD_REMOTE_FNAMEFMT' value.
+    remote_dict : Optional[dict]
+        dictionary of the hemisphere and file type. Default: use
+        the values given for hemi and fileType.
+    username : Optional[str]
+        username to use for an sftp connection.  Default: rcParams'
+        'DBREADUSER' value.
+    password : Optional[str]
+        password to use for an sftp connection.  Default: rcParams'
+        'DBREADPASS' value.
+    port : Optional[int]
+        port to use for an sftp connection.  Deafult: rcParams'
+        'DB_PORT' value.
+    tmpdir : Optional[str]
+        directory to download and source files from locally.  Default:
+        rcParams' 'DAVIT_TMPDIR' value.
+    
+
     Attributes
     -----------
     sTime : (datetime)
         start time of the request
     eTime : (datetime)
         end time of the request
-    hemi : (str)
-        station id of the request
-    fType : (str)
-        the file type, 'grid', 'map'
+    hemi : str
+        hemisphere of data interested in
+    fType : str
+        the file type, 'grd', 'map', 'grdex' or 'mapex'
     recordIndex : (dict)
         look up dictionary for file offsets for scan times
 
@@ -59,7 +107,7 @@ class sdDataPtr():
         the data pointer (different depending on mongodo or dmap)
     fd : (int)
         the file descriptor 
-    filename : (str)
+    fileName : (str)
         name of the file opened
     nocache : (bool)
         do not use cached files, regenerate tmp files 

--- a/davitpy/pydarn/sdio/sdDataTypes.py
+++ b/davitpy/pydarn/sdio/sdDataTypes.py
@@ -194,7 +194,13 @@ class sdDataPtr():
             arr = [fileType]
     
         # a temporary directory to store a temporary file
-        tmpdir = '/tmp/sd/' # THIS NEEDS TO BE FIXED, ISSUE 214
+        if tmpdir is None:
+            try:
+                tmpdir = davitpy.rcParams['DAVIT_TMPDIR']
+            except:
+                logging.warning("Unable to set temporary directory with "
+                                "rcParams. Using extra default of /tmp/sd/")
+                tmpdir = '/tmp/sd/'
         d = os.path.dirname(tmpdir)
         if not os.path.exists(d):
             os.makedirs(d)

--- a/davitpy/pydarn/sdio/sdDataTypes.py
+++ b/davitpy/pydarn/sdio/sdDataTypes.py
@@ -136,8 +136,8 @@ class sdDataPtr():
 
     Written by AJ 20130607
     """
-    def __init__(self, sTime=None, hemi=None, eTime=None, src=None,
-                 fileName=None, fileType=None, noCache=False, local_dirfmt=None,
+    def __init__(self, sTime=None, hemi, eTime=None, src=None,
+                 fileName=None, fileType, noCache=False, local_dirfmt=None,
                  local_fnamefmt=None, local_dict=None, remote_dirfmt=None,
                  remote_fnamefmt=None, remote_dict=None, remote_site=None,
                  username=None, password=None, port=None, tmpdir=None):

--- a/davitpy/pydarn/sdio/sdDataTypes.py
+++ b/davitpy/pydarn/sdio/sdDataTypes.py
@@ -46,14 +46,15 @@ class sdDataPtr():
         start time of the request
     hemi : str
         hemisphere of data interested in
+    fileType : str
+        the type of file: 'grd', 'grdex', 'map', or 'mapex'
     eTime : Optional[datetime]
-        end time of the request
+        end time of the request.  If none, then a full day is
+        requested.
     src : Optional[str]
         source of files: local of sftp
     fileName : Optional[str]
         name of the file opened
-    fileType : str
-        the type of file: 'grd', 'grdex', 'map', or 'mapex'
     noCache : Optional[bool]
         true to not use cached files, regenerate tmp files
     local_dirfmt : Optional[str]
@@ -136,8 +137,8 @@ class sdDataPtr():
 
     Written by AJ 20130607
     """
-    def __init__(self, sTime=None, hemi, eTime=None, src=None,
-                 fileName=None, fileType, noCache=False, local_dirfmt=None,
+    def __init__(self, sTime, hemi, fileType, eTime=None, src=None,
+                 fileName=None, noCache=False, local_dirfmt=None,
                  local_fnamefmt=None, local_dict=None, remote_dirfmt=None,
                  remote_fnamefmt=None, remote_dict=None, remote_site=None,
                  username=None, password=None, port=None, tmpdir=None):


### PR DESCRIPTION
As @aburrell noticed in #214, the tmpdir wasn't being set by the rcParams value.  This has been corrected as well as added documentation to the sdDataPtr class.  Also noted which variables have been set at non-optional based on how the code is setup and/or assert error messages.

I don't have a test for this, although I guess you could set the DAVIT_TMPDIR in your davitpyrc file to something other than /tmp/sd/ .  Then run this code in the develop branch and see that using this file doesn't use the directory set in davitpyrc.

To see that this branch doesn't break anything, at least you could do:

```
from davitpy import *
import datetime

sillyObj = pydarn.sdio.sdDataOpen(datetime.datetime(2015,11,11), hemi='north', fileType='grdex')
```

And then see that the grdex files are in the tmpdir of your choosing.