### PR TITLE
[bugfix] Fixed AttributeError problem caused by incorrect ordering of code

### DIFF
--- a/davitpy/pydarn/plotting/fan.py
+++ b/davitpy/pydarn/plotting/fan.py
@@ -533,6 +533,9 @@ def overlayFan(myData, myMap, myFig, param, coords='geo', gsct=0, site=None,
 
     """
     from davitpy import pydarn
+
+    if(isinstance(myData, pydarn.sdio.beamData)): myData = [myData]
+
     if(site is None):
         site = pydarn.radar.site(radId=myData[0].stid, dt=myData[0].time)
     if(fov is None):
@@ -540,8 +543,6 @@ def overlayFan(myData, myMap, myFig, param, coords='geo', gsct=0, site=None,
                                       ngates=myData[0].prm.nrang + 1,
                                       nbeams=site.maxbeam, coords=coords,
                                       date_time=myData[0].time)
-
-    if(isinstance(myData, pydarn.sdio.beamData)): myData = [myData]
 
     gs_flg, lines = [], []
     if fill: verts, intensities = [], []


### PR DESCRIPTION
As detailed in issue #255, there was a problem with `overlayFan` when passing a `beamData` object. This pull request fixes this issue.

To test the pull request, run the following code (which fails without this pull request as detailed in #255):


    import datetime
    import os
    import davitpy.utils
    import matplotlib.pyplot as plt
    from davitpy import pydarn
    from davitpy.pydarn.plotting import *
    
    sTime = datetime.datetime(2016,5,7,1,36)
    eTime = datetime.datetime(2016,5,7,1,41)
    radar = 'rkn'
    beam = 7
    cp=None
    filtered=False
    src=None
    fileType='fitex'
    channel=None
    
    myPtr=pydarn.sdio.radDataOpen(sTime,radar,eTime=eTime,channel=channel,bmnum=beam,cp=cp,fileType=fileType,filtered=filtered)
    myBeam=pydarn.sdio.radDataReadRec(myPtr)
    
    fig = plt.figure(figsize=(14,12))
    ax=fig.add_subplot(111)
    
    mObj=utils.plotUtils.mapObj(dateTime=sTime,lon_0=93.11,lat_0=72.6,showCoords='True',gridLabels='True',grid='True', height=11E6,width=11E6)
    mObj.nightshade(sTime,alpha=0.1)
    overlayRadar(mObj,codes='rkn',fontSize=12)
    overlayFov(mObj,maxGate=75,codes='rkn',lineWidth=2)
    site = pydarn.radar.site(radId=myBeam.stid, dt=sTime)
    overlayFan(myBeam,mObj,fig,'power',site=site)
    fig.show()

Also, run the testing code in `fan.py` using `python fan.py`.