### PR TITLE
tdiff estimation enhancement

### DIFF
--- a/davitpy/pydarn/proc/fov/__init__.py
+++ b/davitpy/pydarn/proc/fov/__init__.py
@@ -8,3 +8,5 @@ field-of-view (FoV) of SuperDARN backscatter.
 """
 import update_backscatter
 import test_update_backscatter
+import calc_elevation
+import calc_height

--- a/davitpy/pydarn/proc/fov/calc_elevation.py
+++ b/davitpy/pydarn/proc/fov/calc_elevation.py
@@ -1,0 +1,703 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-----------------------------------------------------------------------------
+# calc_elevation.py, Angeline G. Burrell (AGB), UoL
+#
+# Comments: Routines to calculate the elevation angle and its error.
+#-----------------------------------------------------------------------------
+"""calc_elevation
+
+Routines to calculate the elevation angle and its error
+
+Functions
+------------------------------------------------------------------------------
+calc_elv        Calculate elevation angle using phase lag
+calc_elv_w_err  Calculate elevation angle and error using phase lag
+calc_elv_list   Calculate elevation angle using input from lists or np.arrays
+------------------------------------------------------------------------------
+
+Author: Angeline G. Burrell (AGB)
+Date: February 9, 2016
+Inst: University of Leicester (UoL)
+"""
+
+# Import python packages
+import numpy as np
+from scipy import constants as scicon
+import logging
+
+#---------------------------------------------------------------------------
+def calc_elv(beam, phi0_attr="phi0", phi0_e_attr="phi0_e", hard=None,
+             asep=None, ecor=None, phi_sign=None, tdiff=None, del_chi=None,
+             del_chif=0.0, alias=0.0, fov='front'):
+    """Calculate the elevation angle for observations along a beam at a radar
+
+    Parameters
+    -----------
+    beam : (class `pydarn.sdio.radDataTypes.beamData`)
+        Data for a single radar and beam along all range gates at a given time
+    hard : (class `pydarn.radar.radStruct.site` or NoneType)
+        Radar hardware data or None to load here (default=None)
+    asep : (float or NoneType)
+        Antenna separation in meters or None to calculate (default=None)
+    ecor : (float or NoneType)
+        Elevation correction in radians based on the altitude difference between
+        the radar and the interferometer or None to calculate (default=None)
+    phi_sign : (float or NoneType)
+        Sign change determined by the relative location of the interferometer
+        to the radar or None to calculate (default=None)
+    tdiff : (float or NoneType)
+        The relative time delay of the signal paths from the interferometer
+        array to the receiver and the main array to the reciver (microsec) or
+        None to use the value supplied by the hardware file (default=None)
+    del_chi : (float or NoneType)
+        The total phase shift caused by the cables and the filter in radians.
+        If None, will be calculated. (default=None)
+    del_chif : (float)
+        Additional phase shift in radians (default=0.0)
+    alias : (float)
+        Amount to offset the acceptable phase shifts by.  The default phase
+        shift range starts at the calculated max - 2 pi, any (positive) alias
+        will remove 2 pi from the minimum allowable phase shift. (default=0.0)
+    fov : (str)
+        'front' = Calculate elevation angles from front Field-of-View (fov);
+        'back' = Calculate elevation angle from back FoV. (default='front')
+    
+    Returns
+    --------
+    elv : (np.array)
+        A list of floats of the same size as the myBeam.fit.slist list,
+        containing the new elevation angles for each range gate or NaN if an
+        elevation angle could not be calculated
+    phase_amb: (np.array)
+        A list of integers containing the phase ambiguity integer used to
+        alias the elevation angles
+    hard : (class `pydarn.radar.radStruct.site` or NoneType)
+        Radar hardware data or None to load here (default=None)
+    asep : (float or NoneType)
+        Antenna separation in meters or None to calculate (default=None)
+    ecor : (float or NoneType)
+        Elevation correction in radians based on the altitude difference between
+        the radar and the interferometer or None to calculate (default=None)
+    phi_sign : (float or NoneType)
+        Sign change determined by the relative location of the interferometer
+        to the radar or None to calculate (default=None)
+    """
+    import davitpy.pydarn.sdio as sdio
+    import davitpy.pydarn.radar as pyrad
+
+    #-------------------------------------------------------------------------
+    # Test input
+    assert isinstance(beam, sdio.radDataTypes.beamData), \
+        logging.error('the beam must be a beamData class')
+    assert isinstance(phi0_attr, str) and hasattr(beam.fit, phi0_attr), \
+        logging.error('the phase lag data is not in this beam')
+    assert isinstance(hard, pyrad.site) or hard is None, \
+        logging.error('supply the hardware class or None')
+    assert isinstance(asep, float) or asep is None, \
+        logging.error('the asep should be a float or NoneType')
+    assert isinstance(ecor, float) or ecor is None, \
+        logging.error('the ecor should be a float or NoneType')
+    assert isinstance(phi_sign, float) or phi_sign is None, \
+        logging.error('the phi_sign should be a float or NoneType')
+    assert isinstance(tdiff, float) or tdiff is None, \
+        logging.error('the tdiff should be a float or NoneType')
+    assert isinstance(del_chi, float) or del_chi is None, \
+        logging.error('the del_chi should be a float or NoneType')
+    assert isinstance(del_chif, float), \
+        logging.error('the del_chif should be a float')
+    assert isinstance(alias, float), \
+        logging.error('the alias number should be a float')
+    assert(isinstance(fov, str) and (fov.find("front") >= 0 or
+                                     fov.find("back") >= 0)), \
+        logging.error('the field-of-view must be "front" or "back"')
+
+    # Only use this if the interferometer data was stored during this scan
+    assert beam.prm.xcf == 1, \
+        logging.error('no interferometer data at this time')
+
+    # Load the phase lag data
+    phi0 = getattr(beam.fit, phi0_attr)
+
+    # This method cannot be applied at Goose Bay or any other radar/beam that
+    # does not include phi0 in their FIT output
+    assert phi0 is not None, \
+        logging.error('phi0 missing from rad {:d} beam {:d}'.format(beam.stid,
+                                                                    beam.bmnum))
+
+    # If possible, load the phase lag error data (not required to run)
+    if hasattr(beam.fit, phi0_e_attr):
+        phi0_e = getattr(beam.fit, phi0_e_attr)
+    else:
+        phi0_e = [1.0 for p in phi0]
+
+    #-------------------------------------------------------------------------
+    # Initialize output
+    elv = np.empty(shape=(len(phi0),), dtype=float) * np.nan
+    phase_amb = np.zeros(shape=(len(phi0),), dtype=int)
+
+    #-------------------------------------------------------------------------
+    # If desired, load the radar hardware data for the specified site and time
+    if hard is None:
+        hard = pyrad.site(radId=beam.stid, dt=beam.time)
+
+    # Set the proper angle sign based on whether this is backlobe or
+    # front lobe data
+    if fov.find("front") == 0:
+        back = 1.0
+    else:
+        back = -1.0
+
+    # If desired, overwrite the hardware value for tdiff
+    if tdiff is None:
+        tdiff = hard.tdiff
+
+    # If desired, calculate the radar specific variables
+    if asep is None or ecor is None or phi_sign is None:
+        # Calculate the elevation angle correction due to differences in
+        # altitude between the interferometer and the radar and determine
+        # whether the interferometer is in front or behind the radar
+        asep = np.sqrt(np.dot(hard.interfer, hard.interfer)) # meters
+        phi_sign = 1.0 if hard.interfer[1] > 0.0 else -1.0
+        ecor = phi_sign * hard.phidiff * np.arcsin(hard.interfer[2] / asep)
+
+    #-------------------------------------------------------------------------
+    # Calculate the beam-specific variables
+    #
+    # Phi is the beam direction off the radar boresite assuming an elevation
+    # angle of zero.  This is calculated by the hardware routine 'beamToAzim'
+    # located in pydarn.radar.radStruct
+    cos_phi = np.cos(np.radians(hard.beamToAzim(beam.bmnum) - hard.boresite))
+
+    # k is the wavenumber in radians per meter
+    k = 2.0 * np.pi * beam.prm.tfreq * 1.0e3 / scicon.c
+
+    # Calculate the phase shift due to the radar cables and any additional
+    # amount (due to the radar mode, etc.) unless a phase shift was supplied
+    if del_chi is None:
+        del_chi = -np.pi * beam.prm.tfreq * tdiff * 2.0e-3 - del_chif
+
+    # Find the maximum possible phase shift
+    chimax = phi_sign * k * asep * cos_phi
+    chimin = chimax - (alias + 1.0) * phi_sign * 2.0 * np.pi
+    
+    #-------------------------------------------------------------------------
+    # Calculate the elevation for each value of phi0
+    for i,p0 in enumerate(phi0):
+        #---------------------------------------------------------------------
+        # Use only data where the angular drift between signals is not
+        # identically zero with an error of zero, since this could either be a
+        # sloppy flag denoting no data or an actual measurement.
+        if p0 != 0.0 or phi0_e[i] != 0.0:
+            # Find the right phase.  This method works for both front and back
+            # lobe calculations, unlike the more efficient method used by RST
+            # in elevation.c:
+            # phi_tempf = phi0 + 2.0*np.pi* np.floor(((chimax+del_chi)-phi0)/
+            #                                       (2.0*np.pi))
+            # if phi_sign < 0.:
+            #     phi_tempf += 2.0 * np.pi
+            # cos_thetaf = (phi_tempf - del_chi) / (k * asep)
+            # sin2_deltaf = cos_phi**2 - cos_thetaf**2
+            #
+            # They both yield the same elevation for front lobe calculations
+            phi_temp = (back * (p0 - del_chi)) % (2.0 * np.pi)
+            amb_temp = -np.floor(back * (p0 - del_chi) / (2.0 * np.pi))
+
+            # Ensure that phi_temp falls within the proper limits
+            while phi_temp > max(chimax, chimin):
+                phi_temp += phi_sign * 2.0 * np.pi
+                amb_temp += phi_sign
+
+            while abs(phi_temp) < abs(chimin):
+                phi_temp += phi_sign * 2.0 * np.pi
+                amb_temp += phi_sign
+
+            #--------------------------
+            # Evaluate the phase shift
+            if phi_temp > max(chimax, chimin):
+                estr = "can't fix phase shift for beam {:d}".format(beam.bmnum)
+                estr = "{:s} [{:f} not between ".format(estr, phi_temp)
+                estr = "{:s}{:f},{:f} on ".format(estr, chimin, chimax)
+                estr = "{:s}{:} at range gate {:d}".format(estr, beam.time,
+                                                           beam.fit.slist[i])
+                logging.critical(estr)
+            else:
+                # Calcualte the elevation angle and set if realistic
+                cos_theta = phi_temp / (k * asep)
+                sin2_delta = cos_phi**2 - cos_theta**2
+
+                if sin2_delta >= 0.0:
+                    sin_delta = np.sqrt(sin2_delta)
+                    if sin_delta <= 1.0:
+                        new_elv = np.degrees(np.arcsin(sin_delta) + ecor)
+                        elv[i] = new_elv
+                        phase_amb[i] = int(amb_temp)
+
+    return elv, phase_amb, hard, asep, ecor, phi_sign
+
+#---------------------------------------------------------------------------
+def calc_elv_w_err(beam, phi0_attr="phi0", phi0_e_attr="phi0_e", hard=None,
+                   asep=None, ecor=None, phi_sign=None, bmaz_e=0.0,
+                   boresite_e=0.0, ix_e=0.0, iy_e=0.0, iz_e=0.0, tdiff=None,
+                   tdiff_e=0.0, alias=0.0, fov='front'):
+    """Calculate the elevation angle for observations along a beam at a radar
+
+    Parameters
+    -----------
+    beam : (class `pydarn.sdio.radDataTypes.beamData`)
+        Data for a single radar and beam along all range gates at a given time
+    phi0_attr : (str)
+        Name of the phase lag attribute in the beam.fit object (default="phi0")
+    phi0_e_attr : (str)
+        Name of the phase lag error attribute (default="phi0_e")
+    hard : (class `pydarn.radar.radStruct.site` or NoneType)
+        Radar hardware data or None to load here (default=None)
+    asep : (float or NoneType)
+        Antenna separation in meters or None to calculate (default=None)
+    ecor : (float or NoneType)
+        Elevation correction in radians based on the altitude difference between
+        the radar and the interferometer or None to calculate (default=None)
+    phi_sign : (float or NoneType)
+        Sign change determined by the relative location of the interferometer
+        to the radar or None to calculate (default=None)
+    bmaz_e : (float)
+        Error in beam azimuth in degrees (default=0.0)
+    boresite_e : (float)
+        Error in the boresite location in degrees (default=0.0)
+    ix_e : (float)
+        Error in the interferometer x coordinate in meters (default=0.0)
+    iy_e : (float)
+        Error in the interferometer y coordinate in meters (default=0.0)
+    iz_e : (float)
+        Error in the interferometer z coordinate in meters (default=0.0)
+    tdiff : (float or NoneType)
+        The relative time delay of the signal paths from the interferometer
+        array to the receiver and the main array to the reciver (microsec) or
+        None to use the value supplied by the hardware file (default=None)
+    tdiff_e : (float)
+        Error in the tdiff value in microseconds (default=0.0)
+    alias : (float)
+        Amount to offset the acceptable phase shifts by.  The default phase
+        shift range starts at the calculated max - 2 pi, any (positive) alias
+        will remove 2 pi from the minimum allowable phase shift. (default=0.0)
+    fov : (str)
+        'front' = Calculate elevation angles from front Field-of-View (fov);
+        'back' = Calculate elevation angle from back FoV. (default='front')
+    
+    Returns
+    --------
+    elv : (np.array)
+        A list of floats of the same size as the myBeam.fit.slist list,
+        containing the elevation angle for each range gate or NaN if an
+        elevation angle could not be calculated.
+    elv_e : (np.array)
+        A list of floats of the same size as the myBeam.fit.slist list,
+        containing the elevation angle errors for each range gate or NaN if an
+        elevation angle error could not be calculated.
+    phase_amb: (np.array)
+        A list of integers containing the phase ambiguity integer used to
+        alias the elevation angles
+    hard : (class `pydarn.radar.radStruct.site` or NoneType)
+        Radar hardware data or None to load here (default=None)
+    asep : (float or NoneType)
+        Antenna separation in meters or None to calculate (default=None)
+    ecor : (float or NoneType)
+        Elevation correction in radians based on the altitude difference between
+        the radar and the interferometer or None to calculate (default=None)
+    phi_sign : (float or NoneType)
+        Sign change determined by the relative location of the interferometer
+        to the radar or None to calculate (default=None)
+    """
+    import davitpy.pydarn.sdio as sdio
+    import davitpy.pydarn.radar as pyrad
+
+    #-------------------------------------------------------------------------
+    # Test input
+    assert isinstance(beam, sdio.radDataTypes.beamData), \
+        logging.error('the beam must be a beamData class')
+    assert isinstance(phi0_attr, str) and hasattr(beam.fit, phi0_attr), \
+        logging.error('the phase lag data is not in this beam')
+    assert isinstance(phi0_e_attr, str) and hasattr(beam.fit, phi0_attr), \
+        logging.error('the phase lag error data is not in this beam')
+    assert isinstance(hard, pyrad.site) or hard is None, \
+        logging.error('supply the hardware class or None')
+    assert isinstance(asep, float) or asep is None, \
+        logging.error('the asep should be a float or NoneType')
+    assert isinstance(ecor, float) or ecor is None, \
+        logging.error('the ecor should be a float or NoneType')
+    assert isinstance(phi_sign, float) or phi_sign is None, \
+        logging.error('the phi_sign should be a float or NoneType')
+    assert isinstance(tdiff, float) or tdiff is None, \
+        logging.error('the tdiff should be a float or NoneType')
+    assert isinstance(tdiff_e, float) or tdiff is None, \
+        logging.error('the tdiff should be a float or NoneType')
+    assert isinstance(bmaz_e, float), \
+        logging.error('the beam azimuth error should be a float')
+    assert isinstance(boresite_e, float), \
+        logging.error('the boresite error should be a float')
+    assert isinstance(ix_e, float), \
+        logging.error('the interferometer x error should be a float')
+    assert isinstance(iy_e, float), \
+        logging.error('the interferometer y error should be a float')
+    assert isinstance(iz_e, float), \
+        logging.error('the interferometer z error should be a float')
+    assert isinstance(alias, float), \
+        logging.error('the alias number should be a float')
+    assert(isinstance(fov, str) and (fov.find("front") >= 0 or
+                                     fov.find("back") >= 0)), \
+        logging.error('the field-of-view must be "front" or "back"')
+
+    # Only use this if the interferometer data was stored during this scan
+    assert beam.prm.xcf == 1, \
+        logging.error('no interferometer data at this time')
+
+    # Load the phase lag data
+    phi0 = getattr(beam.fit, phi0_attr)
+
+    # This method cannot be applied at Goose Bay or any other radar/beam that
+    # does not include phi0 in their FIT output
+    assert phi0 is not None, \
+        logging.error('phi0 missing from rad {:d} beam {:d}'.format(beam.stid,
+                                                                    beam.bmnum))
+
+    # If possible, load the phase lag error data (not required to run)
+    if hasattr(beam.fit, phi0_e_attr):
+        phi0_e = getattr(beam.fit, phi0_e_attr)
+    else:
+        phi0_e = [np.nan for p in phi0]
+
+    #-------------------------------------------------------------------------
+    # Initialize output
+    elv = np.empty(shape=(len(phi0),), dtype=float) * np.nan
+    elv_e = np.empty(shape=(len(phi0),), dtype=float) * np.nan
+    phase_amb = np.zeros(shape=(len(phi0),), dtype=int)
+
+    #-------------------------------------------------------------------------
+    # If desired, load the radar hardware data for the specified site and time
+    if hard is None:
+        hard = pyrad.site(radId=beam.stid, dt=beam.time)
+
+    # Set the proper angle sign based on whether this is backlobe or
+    # front lobe data
+    if fov.find("front") == 0:
+        back = 1.0
+    else:
+        back = -1.0
+
+    # If desired, overwrite the hardware value for tdiff
+    if tdiff is None:
+        tdiff = hard.tdiff
+
+    # If desired, calculate the radar specific variables
+    if asep is None or ecor is None or phi_sign is None:
+        # Calculate the elevation angle correction due to differences in
+        # altitude between the interferometer and the radar and determine
+        # whether the interferometer is in front or behind the radar
+        asep = np.sqrt(np.dot(hard.interfer, hard.interfer)) # meters
+        phi_sign = 1.0 if hard.interfer[1] > 0.0 else -1.0
+        ecor = phi_sign * hard.phidiff * np.arcsin(hard.interfer[2] / asep)
+
+    # Calculate two of the error coefficients for the interferometer location
+    ecor_coef = phi_sign * hard.phidiff / asep
+    asin_ecor = np.sqrt(1.0 - (hard.interfer[2] / asep)**2)
+
+    #-------------------------------------------------------------------------
+    # Calculate the beam-specific variables
+    #
+    # Phi is the beam direction off the radar boresite assuming an elevation
+    # angle of zero.  This is calculated by the hardware routine 'beamToAzim'
+    # located in pydarn.radar.radStruct
+    bmaz = hard.beamToAzim(beam.bmnum)
+    cos_phi = np.cos(np.radians(bmaz - hard.boresite))
+
+    # k is the wavenumber in radians per meter
+    k = 2.0 * np.pi * beam.prm.tfreq * 1.0e3 / scicon.c
+
+    # Calculate the phase shift due to the radar cables
+    del_chi = -np.pi * beam.prm.tfreq * tdiff * 2.0e-3
+
+    # Find the maximum possible phase shift
+    chimax = phi_sign * k * asep * cos_phi
+    chimin = chimax - (alias + 1.0) * phi_sign * 2.0 * np.pi
+    
+    #-------------------------------------------------------------------------
+    # Calculate the elevation for each value of phi0
+    for i,p0 in enumerate(phi0):
+        #---------------------------------------------------------------------
+        # Use only data where the angular drift between signals is not
+        # identically zero with an error of zero, since this could either be a
+        # sloppy flag denoting no data or an actual measurement.
+        if p0 != 0.0 or np.isnan(phi0_e[i]) or phi0_e[i] != 0.0:
+            # Find the right phase.  This method works for both front and back
+            # lobe calculations, unlike the more efficient method used by RST
+            # in elevation.c:
+            # phi_tempf = phi0 + 2.0*np.pi* np.floor(((chimax+del_chi)-phi0)/
+            #                                       (2.0*np.pi))
+            # if phi_sign < 0.:
+            #     phi_tempf += 2.0 * np.pi
+            # cos_thetaf = (phi_tempf - del_chi) / (k * asep)
+            # sin2_deltaf = cos_phi**2 - cos_thetaf**2
+            #
+            # They both yield the same elevation for front lobe calculations
+            phi_temp = (back * (p0 - del_chi)) % (2.0 * np.pi)
+            amb_temp = -np.floor(back * (p0 - del_chi) / (2.0 * np.pi))
+
+            # Ensure that phi_temp falls within the proper limits
+            while phi_temp > max(chimax, chimin):
+                phi_temp += phi_sign * 2.0 * np.pi
+                amb_temp += phi_sign
+
+            while abs(phi_temp) < abs(chimin):
+                phi_temp += phi_sign * 2.0 * np.pi
+                amb_temp += phi_sign
+
+            #--------------------------
+            # Evaluate the phase shift
+            if phi_temp > max(chimax, chimin):
+                estr = "can't fix phase shift for beam {:d}".format(beam.bmnum)
+                estr = "{:s} [{:f} not between ".format(estr, phi_temp)
+                estr = "{:s}{:f},{:f} on ".format(estr, chimin, chimax)
+                estr = "{:s}{:} at range gate {:d}".format(estr, beam.time,
+                                                           beam.fit.slist[i])
+                logging.critical(estr)
+            else:
+                # Calculate the elevation angle and set if realistic
+                cos_theta = phi_temp / (k * asep)
+                sin2_delta = cos_phi**2 - cos_theta**2
+
+                if sin2_delta >= 0.0:
+                    sin_delta = np.sqrt(sin2_delta)
+                    if sin_delta <= 1.0:
+                        # Calculate the elevation
+                        new_elv = np.degrees(np.arcsin(sin_delta) + ecor)
+                        elv[i] = new_elv
+                        phase_amb[i] = int(amb_temp)
+
+                        # Now that the elevation was calculated, attempt to
+                        # find the elevation error, using the propagation of
+                        # error to propagate all possible uncertainties
+                        asin_der = 1.0 / np.sqrt(sin2_delta - sin2_delta**2)
+
+                        # Calculate the error terms for beam azimuth and
+                        # boresite
+                        term_bmaz = 0.0
+                        term_bore = 0.0
+                        if((not np.isnan(bmaz_e) and bmaz_e > 0.0) or
+                           (not np.isnan(boresite_e) and boresite_e > 0.0)):
+                            sin_phi = np.sin(np.radians(bmaz - hard.boresite))
+
+                            if not np.isnan(bmaz_e) and bmaz_e > 0.0:
+                                temp = (-bmaz * sin_phi * cos_phi * asin_der)**2
+                                term_bmaz = bmaz_e * bmaz_e * temp
+                            if not np.isnan(boresite_e) and boresite_e > 0.0:
+                                temp = (hard.boresite * sin_phi * cos_phi *
+                                        asin_der)**2
+                                term_bore = boresite_e * boresite_e * temp
+
+                        # Calculate the error terms for the interferometer
+                        # location
+                        term_x = 0.0
+                        term_y = 0.0
+                        term_z = 0.0
+                        if((not np.isnan(ix_e) and ix_e > 0.0) or
+                           (not np.isnan(iy_e) and iy_e > 0.0)):
+                            temp = (cos_theta * cos_theta * asin_der +
+                                    ecor_coef * hard.interfer[2] /
+                                    (asep * asep * asin_ecor))
+
+                            if not np.isnan(ix_e) and ix_e > 0.0:
+                                term_x = (ix_e * hard.interfer[0] * temp)**2
+
+                            if not np.isnan(iy_e) and iy_e > 0.0:
+                                term_y = (iy_e * hard.interfer[1] * temp)**2
+
+                        if not np.isnan(iz_e) and iz_e > 0.0:
+                            temp = (cos_theta**2 * asin_der * hard.interfer[2]
+                                    / (asep * asep) - ecor_coef * asin_ecor)
+                            term_z = iz_e * iz_e * temp * temp
+                        
+                        # Calculate the error terms for tdiff
+                        term_tdiff = 0.0
+                        if not np.isnan(tdiff_e) and tdiff_e > 0.0:
+                            temp = (2.0 * np.pi * beam.prm.tfreq * cos_theta /
+                                    (1000.0 * asep * k * asin_der))**2
+                            term_tdiff = temp * tdiff_e * tdiff_e
+
+                        # Calculate the error term for phase lag
+                        term_phi0 = 0.0
+                        if not np.isnan(phi0_e[i]) and phi0_e[i] > 0.0:
+                            temp = cos_theta * asin_der / (k * asep)
+                            term_phi0 = (phi0_e[i] * temp)**2
+
+                        # Calculate the elevation error, adding in quadrature
+                        temp = np.sqrt(term_phi0 + term_tdiff + term_z + term_y
+                                       + term_x + term_bore + term_bmaz)
+
+                        # If the elevation error is identically zero, assume
+                        # that no error could be obtained
+                        elv_e[i] = np.nan if temp == 0.0 else temp
+
+    return elv, elv_e, phase_amb, hard, asep, ecor, phi_sign
+
+
+#---------------------------------------------------------------------------
+def calc_elv_list(phi0, phi0_e, fovflg, cos_phi, tfreq, asep, ecor, phi_sign,
+                  tdiff, alias=0.0):
+    '''Calculate the elevation angle in radians for a single radar
+
+    Parameters
+    -----------
+    phi0 : (list of floats)
+        List of phase lags in radians
+    phi0_e : (list of floats or None)
+        List of phase lag errors in radians
+    fovflg : (list of ints)
+        List of field-of-view flags where 1 indicates the front, -1 the rear
+    cos_phi : (list of floats)
+        Cosine of the azimuthal angle between the beam and the radar boresite
+    tfreq : (list of floats)
+        Transmission frequency (kHz)
+    asep : (float)
+        Antenna separation in meters or None to calculate
+    ecor : (float)
+        Elevation correction in radians based on the altitude difference between
+        the radar and the interferometer
+    phi_sign : (float)
+        Sign change determined by the relative location of the interferometer
+        to the radar
+    tdiff : (float)
+        The relative time delay of the signal paths from the interferometer
+        array to the receiver and the main array to the reciver (microsec)
+    alias : (float)
+        Amount to offset the acceptable phase shifts by.  The default phase
+        shift range starts at the calculated max - 2 pi, any (positive) alias
+        will remove 2 pi from the minimum allowable phase shift. (default=0.0)
+    
+    Returns
+    --------
+    elv : (list)
+        A list of floats containing the new elevation angles for each phi0 in
+        radians or NaN if an elevation angle could not be calculated
+    '''
+    #-------------------------------------------------------------------------
+    # Initialize output
+    elv = list()
+
+    #-------------------------------------------------------------------------
+    # Test input
+    if not isinstance(phi0, list) and not isinstance(phi0, np.ndarray):
+        logging.error("the phase lag must be a list or numpy array")
+        return elv
+
+    if((not isinstance(phi0_e, list) and not isinstance(phi0_e, np.ndarray))
+       or phi0_e is None):
+        estr = "the phase lag error has been discarded, it is not a list or "
+        logging.warn("{:s} numpy array".format(estr))
+        phi0_e = [1.0 for p in phi0]
+
+    if(not isinstance(fovflg, list) and not isinstance(fovflg, np.ndarray)):
+        logging.error("the FoV flag must be a list or numpy array")
+        return elv
+
+    if len(phi0) == 0 or len(phi0_e) != len(phi0) or len(fovflg) != len(phi0):
+        logging.error("the input lists are empty or are not the same size")
+        return elv
+
+    if isinstance(ecor, int):
+        ecor = float(ecor)
+    elif not isinstance(ecor, float):
+        logging.error("the elevation correction must be a float")
+        return elv
+
+    if isinstance(phi_sign, int):
+        phi_sign = float(phi_sign)
+    elif not isinstance(phi_sign, float):
+        logging.error("the phase lag sign must be a float")
+        return elv
+
+    if isinstance(asep, int):
+        asep = float(asep)
+    elif not isinstance(asep, float):
+        logging.error("the interferometer distance must be a float")
+        return elv
+
+    if isinstance(tdiff, int):
+        tdiff = float(tdiff)
+    elif not isinstance(tdiff, float):
+        logging.error("the TDIFF must be a float")
+        return elv
+
+    if isinstance(alias, int):
+        alias = float(alias)
+    elif not isinstance(alias, float):
+        logging.error("the alias must be a float")
+        return elv
+
+    #-------------------------------------------------------------------------
+    # Calculate the elevation for each value of phi0
+    for i,p0 in enumerate(phi0):
+        #---------------------------------------------------------------------
+        # Use only data where the angular drift between signals is not
+        # identically zero with an error of zero, since this could either be a
+        # sloppy flag denoting no data or an actual measurement.
+        if p0 != 0.0 or phi0_e[i] != 0.0 and abs(fovflg[i]) == 1:
+            # Calculate the frequency based values
+            #
+            # k is the wavenumber in radians per meter
+            k = 2.0 * np.pi * tfreq[i] * 1.0e3 / scicon.c
+
+            # Calculate the phase shift due to the radar cables
+            del_chi = -np.pi * tfreq[i] * tdiff * 2.0e-3
+
+            # Find the maximum possible phase shift
+            chimax = phi_sign * k * asep * cos_phi[i]
+            chimin = chimax - (alias + 1.0) * phi_sign * 2.0 * np.pi
+    
+            # Find the right phase.  This method works for both front and back
+            # lobe calculations, unlike the more efficient method used by RST
+            # in elevation.c:
+            # phi_tempf = phi0 + 2.0*np.pi* np.floor(((chimax+del_chi)-phi0)/
+            #                                       (2.0*np.pi))
+            # if phi_sign < 0.:
+            #     phi_tempf += 2.0 * np.pi
+            # cos_thetaf = (phi_tempf - del_chi) / (k * asep)
+            # sin2_deltaf = cos_phi**2 - cos_thetaf**2
+            #
+            # They both yield the same elevation for front lobe calculations
+            phi_temp = (fovflg[i] * (p0 - del_chi)) % (2.0 * np.pi)
+
+            # Ensure that phi_temp falls within the proper limits
+            while phi_temp > max(chimax, chimin):
+                phi_temp += phi_sign * 2.0 * np.pi
+
+            while abs(phi_temp) < abs(chimin):
+                phi_temp += phi_sign * 2.0 * np.pi
+
+            #--------------------------
+            # Evaluate the phase shift
+            if phi_temp > max(chimax, chimin):
+                estr = "BUG: can't fix phase shift [{:f} not ".format(phi_temp)
+                estr = "{:s}between {:f},{:f}] for".format(estr, chimin, chimax)
+                estr = "{:s} index [{:d}]".format(i)
+                logging.critical(estr)
+                elv.append(np.nan)
+            else:
+                # Calcualte the elevation angle and set if realistic
+                cos_theta = phi_temp / (k * asep)
+                sin2_delta = (cos_phi[i] * cos_phi[i]) - (cos_theta * cos_theta)
+
+                if sin2_delta >= 0.0:
+                    sin_delta = np.sqrt(sin2_delta)
+                    if sin_delta <= 1.0:
+                        new_elv = np.arcsin(sin_delta) + ecor
+                        elv.append(new_elv)
+                    else:
+                        elv.append(np.nan)
+                else:
+                    elv.append(np.nan)
+        else:
+            # Pad the elevation and phase ambiguity arrays if insufficient data
+            # is available to calculate the elevation
+            elv.append(np.nan)
+
+    return elv

--- a/davitpy/pydarn/proc/fov/calc_height.py
+++ b/davitpy/pydarn/proc/fov/calc_height.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-----------------------------------------------------------------------------
+# calc_virtual_height.py, Angeline G. Burrell (AGB), UoL
+#
+# Comments: Routines to calculate the height and its error.
+#-----------------------------------------------------------------------------
+"""calc_virtual_height
+
+Routines to calculate the height and its error
+
+Functions
+------------------------------------------------------------------------------
+calc_virtual_height        calculate virtual height
+calc_virtual_height_w_err  calculate virtual height with error
+------------------------------------------------------------------------------
+
+Author: Angeline G. Burrell (AGB)
+Date: February 9, 2016
+Inst: University of Leicester (UoL)
+"""
+
+# Import python packages
+import numpy as np
+from scipy import constants as scicon
+import logging
+
+#---------------------------------------------------------------------------
+def calc_virtual_height(beam, radius, elv=list(), elv_attr="elv", dist=list(),
+                        dist_attr="slist", dist_units=None):
+    """Calculate the virtual height for a specified backscatter distance and
+    elevation angle.
+
+    Parameters
+    -----------
+    beam : (class `pydarn.sdio.radDataTypes.beamData`)
+        Data for a single radar and beam along all range gates at a given time
+    radius : (float)
+        Earth radius in km
+    elv : (list or numpy.array())
+        List containing elevation in degrees, or nothing to load the
+        elevation from the beam (default=list())
+    elv_attr : (string)
+        Name of beam attribute containing the elevation (default="elv")
+    dist : (list or numpy.array())
+        List containing the slant distance from the radar to the reflection
+        location of the backscatter, or nothing to load the distance from the
+        beam. (default=list())
+    dist_attr : (str)
+        Name of beam attribute containing the slant distance.  Be aware that if
+        the default is used, all heights returned will be for .5 hop propogation
+        paths.  (default="slist")
+    dist_units : (string or NoneType)
+        Units of the slant distance to backscatter location data.  May supply
+        "km", "m", or None.  None indicates that the distance is in range gate
+        bins. (default=None)
+    
+    Returns
+    --------
+    height : (numpy.array)
+        An array of floats of the same size as the myBeam.fit.slist list,
+        containing the virtual height for each range gate or NaN if a virtual
+        height could not be calculated
+
+    Notes
+    --------
+    Specifying a single earth radius introduces additional error into the
+    resulting heights.  If the terrestrial radius at the radar location is used,
+    this error is on the order of 0.01-0.1 km (much smaller than the difference
+    between the real and virtual height).
+    """
+    import davitpy.pydarn.sdio as sdio
+
+    #---------------------------------
+    # Check the input
+    if not isinstance(beam, sdio.radDataTypes.beamData):
+        logging.error('the beam must be a beamData class')
+        return None
+
+    if not isinstance(radius, float):
+        logging.error('the radius must be a float')
+        return None
+
+    #---------------------------------
+    # Load elevation
+    if len(elv) == 0 or (len(dist) > 0 and len(elv) != len(dist)):
+        try:
+            elv = getattr(beam.fit, elv_attr)
+
+            if elv is None:
+                logging.error('no elevation available')
+                return None
+        except:
+            logging.error('no elevation attribute [{:s}]'.format(elv_attr))
+            return None
+
+    #---------------------------------
+    # Load the slant range/distance
+    if len(dist) == 0 or len(dist) != len(elv):
+        try:
+            dist = getattr(beam.fit, dist_attr)
+
+            if dist is None:
+                logging.error('no range/distance data available')
+                return None
+
+            if len(dist) != len(elv):
+                logging.error('different number of range and elevation points')
+                return None
+        except:
+            logging.error('no range attribute [{:s}]'.format(dist_attr))
+            return None
+
+    if len(dist) == 0 or len(elv) == 0 or len(elv) != len(dist):
+        logging.error("unable to load matching elevation and distance lists")
+        return None
+
+    #---------------------------------------------------------------------
+    # Ensure that the range/distance (and error) are in km
+    if dist_units is None:
+        # Convert from range gates to km
+        dist = list(5.0e-10 * scicon.c * (np.array(dist) * beam.prm.smsep
+                                          + beam.prm.lagfr))
+    elif dist_units is "m":
+        # Convert from meters to km
+        dist = [d / 1000.0 for d in dist]
+    elif dist_units is not "km":
+        logging.error('unknown range unit [{:s}]'.format(dist_units))
+        return None
+
+    #-----------------------------------------------------------------------
+    # Cycle through the beams and elevations, calculating the virtual height
+    height = np.empty(shape=(len(dist),), dtype=float) * np.nan
+
+    for i,d in enumerate(dist):
+        if not np.isnan(elv[i]):
+            # Calculate height by assuming a spherical earth and solving the
+            # law of cosines for an obtuse triangle with sides radius,
+            # radius + height, and distance, where the angle between the side of
+            # length distance and radius + height is equal to 90 deg - elevation
+            hsqrt = np.sqrt(d**2 + radius**2 + 2.0 * d * radius
+                            * np.sin(np.radians(elv[i])))
+            height[i] = hsqrt - radius
+
+    return height
+
+#---------------------------------------------------------------------------
+def calc_virtual_height_w_err(beam, radius, radius_e=0.0, elv=list(),
+                              elv_attr="elv", elv_e=list(), elv_e_attr="elv_e",
+                              dist=list(), dist_attr="slist", dist_e=list(),
+                              dist_e_attr="slist_e", dist_units=None):
+    """Calculate the virtual height and error for a specified backscatter
+    distance and elevation angle.
+
+    Parameters
+    -----------
+    beam : (class `pydarn.sdio.radDataTypes.beamData`)
+        Data for a single radar and beam along all range gates at a given time
+    radius : (float)
+        Earth radius in km
+    radius_e : (float)
+        Earth radius error in km (default=0.0)
+    elv : (list or numpy.array())
+        List containing elevation in degrees, or nothing to load the
+        elevation from the beam (default=list())
+    elv_attr : (string)
+        Name of beam attribute containing the elevation (default="elv")
+    elv_e : (list or numpy.array())
+        List containing elevation error in degrees, or nothing to load the
+        elevation from the beam (default=list())
+    elv_e_attr : (string)
+        Name of beam attribute containing the elevation error (default="elv_e")
+    dist : (list or numpy.array())
+        List containing the slant distance from the radar to the reflection
+        location of the backscatter, or nothing to load the distance from the
+        beam. (default=list())
+    dist_attr : (str)
+        Name of beam attribute containing the slant distance.  Be aware that if
+        the default is used, all heights returned will be for .5 hop propogation
+        paths.  (default="slist")
+    dist_e : (list or numpy.array())
+        List containing the error in slant distance from the radar to the
+        reflection location of the backscatter, or nothing to load the distance
+        error from the beam. (default=list())
+    dist_e_attr : (str)
+        Name of beam attribute containing the error in slant distance.  Be aware
+        that if the default is used, all height errors returned will be for .5
+        hop propogation paths.  (default="dist_e")
+    dist_units : (string or NoneType)
+        Units of the slant distance to backscatter location data and errors.
+        May supply "km", "m", or None.  None indicates that the distance is in
+        range gate bins. You cannot supply the distance and distance error in
+        different unites.  (default=None)
+    
+    Returns
+    --------
+    height : (numpy.array)
+        An array of floats of the same size as the myBeam.fit.slist list,
+        containing the virtual heights for each range gate or NaN if the
+        virtual height could not be calculated
+    height_err : (numpy.array)
+        An array of floats of the same size as the myBeam.fit.slist list,
+        containing the virtual height error for each range gate or NaN if an
+        error could not be calculated
+
+    Notes
+    --------
+    Specifying a single earth radius introduces additional error into the
+    resulting heights.  If the terrestrial radius at the radar location is used,
+    this error is on the order of 0.01-0.1 km (much smaller than the difference
+    between the real and virtual height). This error can be included by using
+    the radius_e input parameter.
+    """
+    import davitpy.pydarn.sdio as sdio
+
+    #---------------------------------
+    # Check the input
+    if not isinstance(beam, sdio.radDataTypes.beamData):
+        logging.error('the beam must be a beamData class')
+        return None
+
+    if not isinstance(radius, float):
+        logging.error('the radius must be a float')
+        return None
+
+    #---------------------------------
+    # Load elevation
+    if len(elv) == 0 or (len(dist) > 0 and len(elv) != len(dist)):
+        try:
+            elv = getattr(beam.fit, elv_attr)
+
+            if elv is None:
+                logging.error('no elevation available')
+                return None
+        except:
+            logging.error('no elevation attribute [{:s}]'.format(elv_attr))
+            return None
+
+    #---------------------------------
+    # Load elevation error
+    if len(elv_e) == 0 or (len(elv) > 0 and len(elv_e) != len(elv)):
+        try:
+            elv_e = getattr(beam.fit, elv_e_attr)
+
+            if elv_e is None:
+                logging.error('no elevation available')
+                return None
+        except:
+            estr = 'no elevation error attribute [{:s}]'.format(elv_e_attr)
+            logging.info(estr)
+            elv_e = [0.0 for e in elv]
+
+    #---------------------------------
+    # Load the slant range/distance
+    if len(dist) == 0 or len(dist) != len(elv):
+        try:
+            dist = getattr(beam.fit, dist_attr)
+
+            if dist is None:
+                logging.error('no range/distance data available')
+                return None
+
+            if len(dist) != len(elv):
+                logging.error('different number of range and elevation points')
+                return None
+        except:
+            logging.error('no range attribute [{:s}]'.format(dist_attr))
+            return None
+
+    if len(dist) == 0 or len(elv) == 0 or len(elv) != len(dist):
+        logging.error("unable to load matching elevation and distance lists")
+        return None
+
+    #--------------------------------------
+    # Load the slant range/distance error
+    if len(dist_e) == 0 or len(dist_e) != len(dist):
+        try:
+            dist_e = getattr(beam.fit, dist_e_attr)
+
+            if dist_e is None:
+                logging.error('no range/distance errors available')
+                return None
+
+            if len(dist_e) != len(dist):
+                logging.error('different number of distance points and errors')
+                return None
+        except:
+            logging.info('no range error attribute [{:s}]'.format(dist_e_attr))
+            dist_e = [0.0 for d in dist]
+
+    #---------------------------------------------------------------------
+    # Ensure that the range/distance (and error) are in km
+    if dist_units is None:
+        # Convert from range gates to km
+        dist = list(5.0e-10 * scicon.c * (np.array(dist) * beam.prm.smsep
+                                          + beam.prm.lagfr))
+        dist_e = list(5.0e-10 * scicon.c * np.array(dist_e) * beam.prm.smsep)
+    elif dist_units is "m":
+        # Convert from meters to km
+        dist = [d / 1000.0 for d in dist]
+        dist_e = [d / 1000.0 for d in dist_e]
+    elif dist_units is not "km":
+        logging.error('unknown range unit [{:s}]'.format(dist_units))
+        return None
+
+    #-----------------------------------------------------------------------
+    # Cycle through the beams and elevations, calculating the virtual height
+    height = np.empty(shape=(len(dist),), dtype=float) * np.nan
+    height_err = np.empty(shape=(len(dist),), dtype=float) * np.nan
+
+    for i,d in enumerate(dist):
+        if not np.isnan(elv[i]):
+            # Calculate height by assuming a spherical earth and solving the
+            # law of cosines for an obtuse triangle with sides radius,
+            # radius + height, and distance, where the angle between the side of
+            # length distance and radius + height is equal to 90 deg - elevation
+            sin_elv = np.sin(np.radians(elv[i]))
+            hsqrt = np.sqrt(d**2 + radius**2 + 2.0 * d * radius * sin_elv)
+            height[i] = hsqrt - radius
+
+            # Now that the height has been calculated, find the error
+            term_elv = 0.0
+            if not np.isnan(elv_e[i]) or elv_e[i] > 0.0:
+                temp = d * radius * np.cos(np.radians(elv[i])) / hsqrt
+                term_elv = (elv_e[i] * temp)**2
+
+            term_rad = 0.0
+            if not np.isnan(radius_e) or radius_e > 0.0:
+                temp = (radius + d * sin_elv) / hsqrt - 1.0
+                term_rad = (radius_e * temp)**2
+
+            term_d = 0.0
+            if not np.isnan(dist_e[i]) or dist_e[i] > 0.0:
+                temp = (d + radius * sin_elv) / hsqrt
+                term_d = (dist_e[i] * temp)**2
+
+            height_err[i] = np.sqrt(term_rad + term_d + term_elv)
+
+    return height, height_err

--- a/davitpy/pydarn/proc/fov/test_update_backscatter.py
+++ b/davitpy/pydarn/proc/fov/test_update_backscatter.py
@@ -141,8 +141,8 @@ def add_colorbar(figure_handle, contour_handle, zmin, zmax, zinc=6, name=None,
             cb.ax.set_xticklabels(w)
 
     # Change the z scale, if necessary
-    if(scale is "exponetial"):
-        cb.formatter=FormatStrFormatter('%7.2E')
+    if(scale is "exponential"):
+        cb.formatter = ticker.FormatStrFormatter('%7.2E')
 
     # Set the label and update the ticks
     if name is not None:
@@ -174,14 +174,14 @@ def get_sorted_legend_labels(ax, marker_key="reg"):
         ordered list of marker handles
     labels : (list)
         ordered list of marker labels
-
     """
     handles, labels = ax.get_legend_handles_labels()
 
     try:
         lind = {morder[marker_key][ll]:il for il,ll in enumerate(labels)}
     except:
-        lind = {morder[marker_key][float(ll)]:il for il,ll in enumerate(labels)}
+        labels = [float(ll) for ll in labels]
+        lind = {morder[marker_key][ll]:il for il,ll in enumerate(labels)}
     order = [lind[k] for k in sorted(lind.keys())]
 
     return [handles[i] for i in order], [labels[i] for i in order]
@@ -199,7 +199,6 @@ def get_fractional_hop_labels(legend_labels):
     --------
     legend_labels : (list)
         List of strings containing fracitonal hops
-
     """
     for i,ll in enumerate(legend_labels):
         ll = ll.replace("0.5", r"$\frac{1}{2}$")
@@ -225,10 +224,10 @@ def plot_yeoman_plate1(intensity_all="p_l", intensity_sep="fovelv",
                        region_hmax={"D":115.0,"E":150.0,"F":900.0},
                        rg_box=[2,5,10,20], vh_box=[50.0,50.0,50.0,150.0],
                        max_rg=[5,25,40,76], max_hop=3.0,
-                       ut_box=dt.timedelta(minutes=20.0), tdiff=list(),
-                       tdiff_e=list(), tdiff_time=list(), ptest=True, step=6,
-                       strict_gs=True, draw=True, label_type="frac",
-                       beams=dict()):
+                       ut_box=dt.timedelta(minutes=20.0), tdiff=None,
+                       tdiff_args=list(), tdiff_e=None, tdiff_e_args=list(),
+                       ptest=True, step=6, strict_gs=True, draw=True,
+                       label_type="frac", beams=dict()):
     """Plot based on Plate 1  in Yeoman et al (2001) Radio Science, 36, 801-813.
 
 
@@ -314,14 +313,27 @@ def plot_yeoman_plate1(intensity_all="p_l", intensity_sep="fovelv",
     ut_box : (class dt.timedelta)
         Total width of universal time box to examine for backscatter FoV
         continuity. (default=20.0 minutes)
-    tdiff : (list)
-        A list of tdiff values (in microsec) or an empty list (to use the
-        hardware value) (default=list())
-    tdiff_e : (list)
-        A list containing the tdiff error (in microsec) or an empty list
-        (no elevation/virtual height error will be computed). (default=list())
-    tdiff_time : (list)
-        A list containing the starting time (datetimes) for each tdiff.
+    tdiff : (function or NoneType)
+        A function to retrieve tdiff values (in microsec) using the radar ID
+        number current datetime, and transmisson frequency as input.
+        Additional inputs may be specified using tdiff_args.  Example:
+        def get_tdiff(stid, time, tfreq, filename) { do things } return tdiff
+        tdiff=get_tdiff, tdiff_args=["tdiff_file"]
+        (default=None)
+    tdiff_args : (list)
+        A list specifying any arguements other than radar, time, and
+        transmission frequency to run the specified tdiff function.
+        (default=list())
+    tdiff_e : function or NoneType)
+        A function to retrieve tdiff error values (in microsec) using the radar
+        ID number, current datetime, and transmisson frequency as input.
+        Additional inputs may be specified using tdiff_e_args.  Example:
+        def get_tdiffe(stud, time, tfreq, filename) { do things } return tdiffe
+        tdiff_e=get_tdiffe, tdiff_e_args=["tdiff_file"]
+        (default=None)
+    tdiff_e_args : (list)
+        A list specifying any arguements other than radar, time, and
+        transmission frequency to run the specified tdiff_e function.
         (default=list())
     ptest : (boolian)
         Test to see if a propagation path is realistic (default=True)
@@ -347,10 +359,8 @@ def plot_yeoman_plate1(intensity_all="p_l", intensity_sep="fovelv",
     beams : (dict)
         Dictionary with radar codes as keys for the dictionaries containing
         beams with the data used to create the plots
-
     """
     import davitpy.pydarn.radar as pyrad
-    rn = "plot_yeoman_plate1"
 
     # Load and process the desired data
     dout = load_test_beams(intensity_all, intensity_sep, stime, etime,
@@ -361,11 +371,14 @@ def plot_yeoman_plate1(intensity_all="p_l", intensity_sep="fovelv",
                            region_hmax=region_hmax, region_hmin=region_hmin,
                            rg_box=rg_box, vh_box=vh_box, max_rg=max_rg,
                            max_hop=max_hop, ut_box=ut_box, tdiff=tdiff,
-                           tdiff_e=tdiff_e, tdiff_time=tdiff_time, ptest=ptest,
-                           step=step, strict_gs=strict_gs, beams=beams)
+                           tdiff_args=tdiff_args, tdiff_e=tdiff_e,
+                           tdiff_e_args=tdiff_e_args, ptest=ptest, step=step,
+                           strict_gs=strict_gs, beams=beams)
 
     rad = rad_bms.keys()[0]
     if not dout[0].has_key(rad) or len(dout[0][rad]) == 0:
+        estr = "can't find radar [" + rad + "] in data:" + dout[0].keys()
+        logging.error(estr)
         return(dout[0], dout[1], dout[2], beams)
 
     # Recast the data as numpy arrays
@@ -524,10 +537,10 @@ def plot_milan_figure9(intensity_all="p_l", intensity_sep="p_l",
                        region_hmin={"D":75.0,"E":115.0,"F":150.0},
                        rg_box=[2,5,10,20], vh_box=[50.0,50.0,50.0,150.0],
                        max_rg=[5,25,40,76], max_hop=3.0,
-                       ut_box=dt.timedelta(minutes=20.0), tdiff=list(),
-                       tdiff_e=list(), tdiff_time=list(), ptest=True, step=6,
-                       strict_gs=True, draw=True, label_type="frac",
-                       beams=dict()):
+                       ut_box=dt.timedelta(minutes=20.0), tdiff=None,
+                       tdiff_args=list(), tdiff_e=None, tdiff_e_args=list(),
+                       ptest=True, step=6, strict_gs=True, draw=True,
+                       label_type="frac", beams=dict()):
     """Plot based on Figure 9 in Milan et al (1997) Annales Geophysicae, 15,
     29-39.
 
@@ -600,14 +613,27 @@ def plot_milan_figure9(intensity_all="p_l", intensity_sep="p_l",
     ut_box : (class dt.timedelta)
         Total width of universal time box to examine for backscatter FoV
         continuity. (default=20.0 minutes)
-    tdiff : (list)
-        A list of tdiff values (in microsec) or an empty list (to use the
-        hardware value) (default=list())
-    tdiff_e : (list)
-        A list containing the tdiff error (in microsec) or an empty list
-        (no elevation/virtual height error will be computed). (default=list())
-    tdiff_time : (list)
-        A list containing the starting time (datetimes) for each tdiff.
+    tdiff : (function or NoneType)
+        A function to retrieve tdiff values (in microsec) using the radar ID
+        number current datetime, and transmisson frequency as input.
+        Additional inputs may be specified using tdiff_args.  Example:
+        def get_tdiff(stid, time, tfreq, filename) { do things } return tdiff
+        tdiff=get_tdiff, tdiff_args=["tdiff_file"]
+        (default=None)
+    tdiff_args : (list)
+        A list specifying any arguements other than radar, time, and
+        transmission frequency to run the specified tdiff function.
+        (default=list())
+    tdiff_e : function or NoneType)
+        A function to retrieve tdiff error values (in microsec) using the radar
+        ID number, current datetime, and transmisson frequency as input.
+        Additional inputs may be specified using tdiff_e_args.  Example:
+        def get_tdiffe(stud, time, tfreq, filename) { do things } return tdiffe
+        tdiff_e=get_tdiffe, tdiff_e_args=["tdiff_file"]
+        (default=None)
+    tdiff_e_args : (list)
+        A list specifying any arguements other than radar, time, and
+        transmission frequency to run the specified tdiff_e function.
         (default=list())
     ptest : (boolian)
         Test to see if a propagation path is realistic (default=True)
@@ -635,7 +661,6 @@ def plot_milan_figure9(intensity_all="p_l", intensity_sep="p_l",
     beams : (dict)
         Dictionary with radar codes as keys for the dictionaries containing
         beams with the data used to create the plots
-
     """
 
     # Load and process the desired data
@@ -646,12 +671,14 @@ def plot_milan_figure9(intensity_all="p_l", intensity_sep="p_l",
                            min_pnts=min_pnts, region_hmax=region_hmax,
                            region_hmin=region_hmin, rg_box=rg_box,
                            vh_box=vh_box, max_rg=max_rg, max_hop=max_hop,
-                           ut_box=ut_box, tdiff=tdiff, tdiff_e=tdiff_e,
-                           tdiff_time=tdiff_time, ptest=ptest, step=step,
-                           strict_gs=strict_gs, beams=beams)
+                           ut_box=ut_box, tdiff=tdiff, tdiff_args=tdiff_args,
+                           tdiff_e=tdiff_e, tdiff_e_args=tdiff_e_args,
+                           ptest=ptest, step=step, strict_gs=strict_gs,
+                           beams=beams)
 
     if not dout[0].has_key(rad) or len(dout[0][rad]) == 0:
-        logging.error("can't find radar [" + rad + "] in data:" + dout[0].keys())
+        estr = "can't find radar [" + rad + "] in data:" + dout[0].keys()
+        logging.error(estr)
         return(dout[0], dout[1], dout[2], beams)
 
     # Recast the data as numpy arrays
@@ -710,7 +737,7 @@ def plot_storm_figures(intensity_all="v", intensity_sep="v", marker_key="reg",
                        mtimes=[dt.datetime(1997,10,10,16),
                                dt.datetime(1997,10,10,17,30),
                                dt.datetime(1997,10,10,18,30),
-                               dt.datetime(1997,10,10,19,30)],
+                               dt.datetime(1997,10,10,19,30)], coords="mlt",
                        imin={"v":-500.0}, imax={"v":500.0}, zinc={"v":5.0},
                        rad="pyk", bmnum=0, cp=None, figname_time=None,
                        figname_maps=None, password=True, file_type="fitacf",
@@ -719,10 +746,10 @@ def plot_storm_figures(intensity_all="v", intensity_sep="v", marker_key="reg",
                        region_hmin={"D":75.0,"E":115.0,"F":150.0},
                        rg_box=[2,5,10,20], vh_box=[50.0,50.0,50.0,150.0],
                        max_rg=[5,25,40,76], max_hop=3.0,
-                       ut_box=dt.timedelta(minutes=20.0), tdiff=list(),
-                       tdiff_e=list(), tdiff_time=list(), ptest=True, step=6,
-                       strict_gs=True, draw=True, label_type="frac",
-                       beams=dict()):
+                       ut_box=dt.timedelta(minutes=20.0), tdiff=None,
+                       tdiff_args=list(), tdiff_e=None, tdiff_e_args=list(),
+                       ptest=True, step=6, strict_gs=True, draw=True,
+                       label_type="frac", beams=dict()):
     """Plot showing a period of time where E-region scatter past over the
     radar at pyk.
 
@@ -730,12 +757,13 @@ def plot_storm_figures(intensity_all="v", intensity_sep="v", marker_key="reg",
     -----------
     intensity_all : (str)
         Intensity attribute to plot in the top figure with unseperated fields-
-        of-view.  Uses SuperDARN beam fit attribute names. (default="v")
+        of-view.  Uses SuperDARN beam fit attribute names. (default='v')
     intensity_sep : (str)
         Intensity attribute to plot in the separated fields-of-view.  Uses
-        SuperDARN beam fit attribute names. (default="fovelv")
+        SuperDARN beam fit attribute names. (default='fovelv')
     marker_key : (str)
-        key to denote what type of marker labels are being used (default="reg")
+        key to denote what type of marker labels are being used, including:
+        'region', 'reg', and 'hop'. (default='reg')
     color : (dict of str)
         Intensity color scheme.  Defaults to the standard centered color
         scheme for this program.
@@ -754,6 +782,8 @@ def plot_storm_figures(intensity_all="v", intensity_sep="v", marker_key="reg",
         Times to plot maps, unless no times are provided.
         (default=[dt.datetime(1997,10,10,16), dt.datetime(1997,10,10,17,30),
                   dt.datetime(1997,10,10,18,30), dt.datetime(1997,10,10,19,30)])
+    coords : (str)
+        Type of map to plot ("geo" or "mlt") (default="mlt")
     imin : (dict)
         Dictionary of intensity minimums (default={"v":-500.0})
     imax : (dict)
@@ -806,14 +836,27 @@ def plot_storm_figures(intensity_all="v", intensity_sep="v", marker_key="reg",
     ut_box : (class dt.timedelta)
         Total width of universal time box to examine for backscatter FoV
         continuity. (default=20.0 minutes)
-    tdiff : (list)
-        A list of tdiff values (in microsec) or an empty list (to use the
-        hardware value) (default=list())
-    tdiff_e : (list)
-        A list containing the tdiff error (in microsec) or an empty list
-        (no elevation/virtual height error will be computed). (default=list())
-    tdiff_time : (list)
-        A list containing the starting time (datetimes) for each tdiff.
+    tdiff : (function or NoneType)
+        A function to retrieve tdiff values (in microsec) using the radar ID
+        number current datetime, and transmisson frequency as input.
+        Additional inputs may be specified using tdiff_args.  Example:
+        def get_tdiff(stid, time, tfreq, filename) { do things } return tdiff
+        tdiff=get_tdiff, tdiff_args=["tdiff_file"]
+        (default=None)
+    tdiff_args : (list)
+        A list specifying any arguements other than radar, time, and
+        transmission frequency to run the specified tdiff function.
+        (default=list())
+    tdiff_e : function or NoneType)
+        A function to retrieve tdiff error values (in microsec) using the radar
+        ID number, current datetime, and transmisson frequency as input.
+        Additional inputs may be specified using tdiff_e_args.  Example:
+        def get_tdiffe(stud, time, tfreq, filename) { do things } return tdiffe
+        tdiff_e=get_tdiffe, tdiff_e_args=["tdiff_file"]
+        (default=None)
+    tdiff_e_args : (list)
+        A list specifying any arguements other than radar, time, and
+        transmission frequency to run the specified tdiff_e function.
         (default=list())
     ptest : (boolian)
         Test to see if a propagation path is realistic (default=True)
@@ -839,9 +882,9 @@ def plot_storm_figures(intensity_all="v", intensity_sep="v", marker_key="reg",
     beams : (dict)
         Dictionary with radar codes as keys for the dictionaries containing
         beams with the data used to create the plots
-
     """
     import davitpy.pydarn.radar as pyrad
+    import davitpy.utils as dutils
 
     # Load and process the desired data
     dout = load_test_beams(intensity_all, intensity_sep, stime, etime,
@@ -851,11 +894,14 @@ def plot_storm_figures(intensity_all="v", intensity_sep="v", marker_key="reg",
                            min_pnts=min_pnts, region_hmax=region_hmax,
                            region_hmin=region_hmin, rg_box=rg_box,
                            vh_box=vh_box, max_rg=max_rg, max_hop=max_hop,
-                           ut_box=ut_box, tdiff=tdiff, tdiff_e=tdiff_e,
-                           tdiff_time=tdiff_time, ptest=ptest, step=step,
-                           strict_gs=strict_gs, beams=beams)
+                           ut_box=ut_box, tdiff=tdiff, tdiff_args=tdiff_args,
+                           tdiff_e=tdiff_e, tdiff_e_args=tdiff_e_args,
+                           ptest=ptest, step=step, strict_gs=strict_gs,
+                           beams=beams)
 
     if not dout[0].has_key(rad) or len(dout[0][rad]) == 0:
+        estr = "can't find radar [" + rad + "] in data:" + dout[0].keys()
+        logging.error(estr)
         return(dout[0], dout[1], dout[2], beams)
 
     # Recast the data as numpy arrays
@@ -900,42 +946,183 @@ def plot_storm_figures(intensity_all="v", intensity_sep="v", marker_key="reg",
                 a.plot([mt, mt], [-1, 76], "k--")
 
         # Initialize the map figure
-        fmap = plt.figure(figsize=(12, 3 * mlen))
-        nrows = int(np.ceil(0.5*mlen))
-        axmap = [fmap.add_subplot(2, nrows, ia+1) for ia in range(mlen)]
-        hard = None
-        fovs = {1:None, -1:None}
-        mm = None
-        for ia,mt in enumerate(sorted(mtimes)):
-            scan = list()
-            for k in beams[rad].keys():
-                j = 0
-                while j < len(beams[rad][k]):
-                    if beams[rad][k][j].scan_time > mt:
-                        break
-                    elif beams[rad][k][j].scan_time == mt:
-                        scan.append(beams[rad][k][j])
-                    j += 1
+        if coords.lower() == "geo":
+            fmap = plt.figure(figsize=(12, 3 * mlen))
+            nrows = int(np.ceil(0.5*mlen))
+            axmap = [fmap.add_subplot(2, nrows, ia+1) for ia in range(mlen)]
+            hard = None
+            fovs = {1:None, -1:None}
+            mmm = None
+            for ia,mt in enumerate(sorted(mtimes)):
+                scan = list()
+                for k in beams[rad].keys():
+                    j = 0
+                    while j < len(beams[rad][k]):
+                        if beams[rad][k][j].scan_time > mt:
+                            break
+                        elif beams[rad][k][j].scan_time == mt:
+                            scan.append(beams[rad][k][j])
+                        j += 1
 
-            llab = True if ia % 2 == 0 else False
-            axmap[ia].set_axis_bgcolor(acolor)
-            mm, fovs, hard, con = plot_map(axmap[ia], scan, hard=hard,
-                                           map_handle=mm, fovs=fovs,
-                                           plot_beams={1:[bmnum],-1:[bmnum]},
-                                           color_beams={1:["0.6"],-1:["0.6"]},
-                                           maxgates=45, dat_attr=intensity_all,
-                                           fov_attr="fovflg",
-                                           dmax=imax[intensity_all],
-                                           dmin=imin[intensity_all],
-                                           dcolor=color[intensity_all],
-                                           lat_label=llab, draw=False)
+                llab = True if ia % 2 == 0 else False
+                axmap[ia].set_axis_bgcolor(acolor)
+                mm, fovs, hard, con = plot_map(axmap[ia], scan, hard=hard,
+                                               map_handle=mm, fovs=fovs,
+                                               plot_beams={1:[bmnum],
+                                                           -1:[bmnum]},
+                                               color_beams={1:["0.6"],
+                                                            -1:["0.6"]},
+                                               maxgates=45,
+                                               dat_attr=intensity_all,
+                                               fov_attr="fovflg",
+                                               dmax=imax[intensity_all],
+                                               dmin=imin[intensity_all],
+                                               dcolor=color[intensity_all],
+                                               lat_label=llab, draw=False)
 
-        label = pyrad.radUtils.getParamDict(intensity_all)['label']
-        unit = pyrad.radUtils.getParamDict(intensity_all)['unit']
-        cbmap = add_colorbar(fmap, con, imin[intensity_all],
-                             imax[intensity_all], zinc[intensity_all],
-                             label, unit, loc=[0.91,.1,.01,.8])
-        plt.subplots_adjust(wspace=.05)
+            label = pyrad.radUtils.getParamDict(intensity_all)['label']
+            unit = pyrad.radUtils.getParamDict(intensity_all)['unit']
+            cbmap = add_colorbar(fmap, con, imin[intensity_all],
+                                 imax[intensity_all], zinc[intensity_all],
+                                 label, unit, loc=[0.91,.1,.01,.8])
+            plt.subplots_adjust(wspace=.05)
+        elif coords.lower() == "mlt":
+            fov_dir = {1:"front", -1:"back"}
+
+            # Determine the largest and smallest MLTs
+            mlts = np.ndarray(shape=mlen, dtype=float) * np.nan
+            quarters = np.zeros(shape=mlen, dtype=int)
+            hard = list()
+            for ia,mt in enumerate(mtimes):
+                hard.append(pyrad.site(code=rad, dt=mt))
+                mlon = dutils.coordUtils.coord_conv(hard[ia].geolon,
+                                                    hard[ia].geolat, "geo",
+                                                    "mlt", 300.0, mt)[0]
+                
+                mlts[ia] = mlon * 24.0 / 360.0
+                if mlts[ia] < 0.0:
+                    mlts[ia] = mlts[ia] + 24.0
+                if mlts[ia] >= 24.0:
+                    mlts[ia] = mlts[ia] - 24.0
+
+                # Assign MLT clock corners
+                if mlts[ia] < 12.0 and mlts[ia] >= 6.0:
+                    quarters[ia] = 1
+                elif mlts[ia] < 6.0:
+                    quarters[ia] = 2
+                elif mlts[ia] >= 18.0:
+                    quarters[ia] = 3
+                else:
+                    quarters[ia] = 4
+
+            quarters = list(set(quarters))
+            qlen = len(quarters)
+            qmin = min(quarters)
+            qmax = max(quarters)
+            fwidth = 12 if qlen>2 or (qlen>1 and qmin<3 and qmax>2) else 6
+            fheight = 6
+            if(qlen > 2 or (qlen > 1 and (qmin > 1 and qmin < 4 and qmax == 4)
+                            or (qmin == 1 and qmax < 4))):
+               fheight *= 2
+            proj = "npstere" if hard[0].geolat > 0.0 else "spstere"
+            boundinglat = (np.sign(hard[0].geolat) *
+                           (np.floor(abs(hard[0].geolat) / 10.0 - 1.0) * 10.0))
+            boundinglat = 56.0
+            mwidth = 111.0e3 * boundinglat * fwidth / 6.0
+            mheight = 111.0e3 * boundinglat * fheight / 6.0
+            lat_0 = np.sign(hard[0].geolat) * 90.0
+            lon_0 = 0.0
+
+            fmap = plt.figure(figsize=(12,12))
+            axmap = fmap.add_subplot(1,1,1)
+            axmap.set_axis_bgcolor(acolor)
+
+            # Cycle through times
+            for ia,mt in enumerate(sorted(mtimes)):
+                # Load data
+                scan = list()
+                for k in beams[rad].keys():
+                    j = 0
+                    while j < len(beams[rad][k]):
+                        if beams[rad][k][j].scan_time > mt:
+                            break
+                        elif beams[rad][k][j].scan_time == mt:
+                            scan.append(beams[rad][k][j])
+                        j += 1
+
+                # Initialize map, hardware data, and fovs
+                fovs = {ff:pyrad.radFov.fov(site=hard[ia],
+                                            rsep=scan[0].prm.rsep,
+                                            nbeams=hard[ia].maxbeam, ngates=45,
+                                            bmsep=hard[ia].bmsep, model="IS",
+                                            coords=coords, date_time=mt,
+                                            fov_dir=fov_dir[ff])
+                        for ff in [1,-1]}
+                mmm = dutils.plotUtils.mapObj(ax=axmap, datetime=mt,
+                                              coords=coords, projection=proj,
+                                              resolution="c", lon_0=0, lat_0=90,
+                                              boundinglat=boundinglat,
+                                              draw_map=False, grid=True,
+                                              gridLabels=False, round=True)
+
+                mmm, fovs, hh, con = plot_map(axmap, scan, hard=hard[ia],
+                                              map_handle=mmm, fovs=fovs,
+                                              plot_beams={1:[bmnum],-1:[bmnum]},
+                                              color_beams={1:["0.6"],
+                                                           -1:["0.6"]},
+                                              maxgates=45,
+                                              dat_attr=intensity_all,
+                                              fov_attr="fovflg",
+                                              dmax=imax[intensity_all],
+                                              dmin=imin[intensity_all],
+                                              dcolor=color[intensity_all],
+                                              draw_map=False, plot_name=False,
+                                              draw=False)
+                axmap.set_title("")
+
+            # Add clock hours
+            (xmin, xmax) = axmap.get_xlim()
+            (ymin, ymax) = axmap.get_ylim()
+            axmap.text(xmax*0.47, ymax*1.01, "12:00", fontsize="medium")
+            axmap.text(xmax*0.47, -ymax*0.02, "00:00", fontsize="medium")
+            axmap.text(-xmax*0.07, ymax*0.495, "18:00", fontsize="medium")
+            axmap.text(xmax*1.01, ymax*0.495, "06:00", fontsize="medium")
+            axmap.text(xmax*0.86, ymax*0.12, "03:00", fontsize="medium")
+            axmap.text(xmax*0.09, ymax*0.12, "21:00", fontsize="medium")
+            axmap.text(xmax*0.09, ymax*0.87, "15:00", fontsize="medium")
+            axmap.text(xmax*0.86, ymax*0.86, "09:00", fontsize="medium")
+            fmap.suptitle("{:s} Magnetic Local Time".format(rad.upper()))
+
+            # Fix axis and figure limits
+            if fwidth < 12:
+                if qmin > 2:
+                    axmap.set_xlim(xmin, xmax * 0.51)
+                else:
+                    axmap.set_xlim(xmax * 0.49, xmax)
+            if fheight < 12:
+                if qmax < 4 and qmin > 1:
+                    axmap.set_ylim(ymin, ymax * 0.51)
+                else:
+                    axmap.set_ylim(ymax * 0.49, ymax)
+
+            if fwidth < 12 or fheight < 12:
+                fmap.set_size_inches(fwidth, fheight)
+
+            label = pyrad.radUtils.getParamDict(intensity_all)['label']
+            unit = pyrad.radUtils.getParamDict(intensity_all)['unit']
+            cbmap = add_colorbar(fmap, con, imin[intensity_all],
+                                 imax[intensity_all], zinc[intensity_all],
+                                 label, unit, orient="horizontal",
+                                 loc=[0.1,.05,.8,.01])
+
+            
+        else:
+            estr = "{:s} WARNING: unknown coordinate ".format(rn)
+            estr = "{:s}format [{:}]".format(estr, coords)
+            logging.warning(estr)
+            fmap = None
+            axmap = None
+            cbmap = None
     else:
         fmap = None
         axmap = None
@@ -1036,12 +1223,17 @@ def plot_single_column(f, xdata, ydata, zdata, zindices, zname, color,
         Figure handle
     ax : (dict)
         Dictionary of axis handles
-
     """
     import davitpy.pydarn.radar as pyrad
 
+    # Ensure the z limits have been set
+    if zmin is None:
+        zmin = {ff:zdata[ff].min() for ff in zdata.keys()}
+    if zmax is None:
+        zmax = {ff:zdata[ff].max() for ff in zdata.keys()}
+
     # Initialize the subplots
-    xpos = {7:1.1, 6:1.0, 5:0.9, 4:0.8, 3:0.7, 2:0.5, 1:0.0}
+    xpos = {8:1.1, 7:1.1, 6:1.0, 5:0.9, 4:0.8, 3:0.7, 2:0.5, 1:0.0}
     iax = {ff:i for i,ff in enumerate(["all",1,-1,0])}
     ax = {ff:f.add_subplot(4,1,iax[ff]+1) for ff in iax.keys()}
     ypos = 0.89
@@ -1081,9 +1273,9 @@ def plot_single_column(f, xdata, ydata, zdata, zindices, zname, color,
                 zz = zindices[ff][hh]
                 ll = hh if isinstance(hh, str) else "{:.1f}".format(hh)
                 if ii is 'hop' or ii is 'reg':
-                    ax[ff].plot(xdata[zz], ydata[zz], mm[marker_key][hh], ms=5,
-                                markeredgecolor="face",
-                                color=mc[marker_key][hh], label=ll)
+                    ax[ff].plot(xdata[zz], ydata[zz], "|", ms=5, linewidth=3,
+                                color=mc[marker_key][hh],
+                                markeredgecolor=mc[marker_key][hh], label=ll)
                 elif len(zz) > 0:
                     if isinstance(color[ii], str):
                         cmap = cm.get_cmap(color[ii])
@@ -1115,8 +1307,25 @@ def plot_single_column(f, xdata, ydata, zdata, zindices, zname, color,
                         handles.insert(jl, hl[il])
 
         # Format the axes; add titles, colorbars, and labels
+        if xmin is None:
+            try:
+                xmin = xdata.min()
+            except: pass
+        if xmax is None:
+            try:
+                xmax = xdata.max()
+            except: pass
         if xmin is not None and xmax is not None:
             ax[ff].set_xlim(xmin, xmax)
+
+        if ymin is None:
+            try:
+                ymin = ydata.min()
+            except: pass
+        if ymax is None:
+            try:
+                ymax = ydata.max()
+            except: pass
         if ymin is not None and ymax is not None:
             ax[ff].set_ylim(ymin, ymax)
 
@@ -1178,9 +1387,9 @@ def load_test_beams(intensity_all, intensity_sep, stime, etime, rad_bms,
                     region_hmax={"D":115.0,"E":150.0,"F":900.0},
                     rg_box=[2,5,10,20], vh_box=[50.0,50.0,50.0,150.0],
                     max_rg=[5,25,40,76], max_hop=3.0,
-                    ut_box=dt.timedelta(minutes=20.0),tdiff=list(),
-                    tdiff_e=list(), tdiff_time=list(), ptest=True, step=6,
-                    strict_gs=True, beams=dict()):
+                    ut_box=dt.timedelta(minutes=20.0),tdiff=None,
+                    tdiff_args=list(), tdiff_e=None, tdiff_e_args=list(),
+                    ptest=True, step=6, strict_gs=True, beams=dict()):
     """Load data for a test period, updating the beams to include origin field-
     of-view data and returning dictionaries of lists with time, range,
     and intensity data for a specified radar/beam combination.
@@ -1244,14 +1453,27 @@ def load_test_beams(intensity_all, intensity_sep, stime, etime, rad_bms,
     ut_box : (class dt.timedelta)
         Total width of universal time box to examine for backscatter FoV
         continuity. (default=20.0 minutes)
-    tdiff : (list)
-        A list of tdiff values (in microsec) or an empty list (to use the
-        hardware value) (default=list())
-    tdiff_e : (list)
-        A list containing the tdiff error (in microsec) or an empty list
-        (no elevation/virtual height error will be computed). (default=list())
-    tdiff_time : (list)
-        A list containing the starting time (datetimes) for each tdiff.
+    tdiff : (function or NoneType)
+        A function to retrieve tdiff values (in microsec) using the radar ID
+        number current datetime, and transmisson frequency as input.
+        Additional inputs may be specified using tdiff_args.  Example:
+        def get_tdiff(stid, time, tfreq, filename) { do things } return tdiff
+        tdiff=get_tdiff, tdiff_args=["tdiff_file"]
+        (default=None)
+    tdiff_args : (list)
+        A list specifying any arguements other than radar, time, and
+        transmission frequency to run the specified tdiff function.
+        (default=list())
+    tdiff_e : function or NoneType)
+        A function to retrieve tdiff error values (in microsec) using the radar
+        ID number, current datetime, and transmisson frequency as input.
+        Additional inputs may be specified using tdiff_e_args.  Example:
+        def get_tdiffe(stud, time, tfreq, filename) { do things } return tdiffe
+        tdiff_e=get_tdiffe, tdiff_e_args=["tdiff_file"]
+        (default=None)
+    tdiff_e_args : (list)
+        A list specifying any arguements other than radar, time, and
+        transmission frequency to run the specified tdiff_e function.
         (default=list())
     ptest : (boolian)
         Test to see if a propagation path is realistic (default=True)
@@ -1275,7 +1497,6 @@ def load_test_beams(intensity_all, intensity_sep, stime, etime, rad_bms,
     beams : (dict)
         Dictionary with radar codes as keys for the dictionaries containing
         beams with the data used to create the plots
-
     """
     import davitpy.pydarn.sdio as sdio
 
@@ -1326,8 +1547,9 @@ def load_test_beams(intensity_all, intensity_sep, stime, etime, rad_bms,
                                                rg_box=rg_box, vh_box=vh_box,
                                                max_rg=max_rg, max_hop=max_hop,
                                                ut_box=ut_box, tdiff=tdiff,
+                                               tdiff_args=tdiff_args,
                                                tdiff_e=tdiff_e,
-                                               tdiff_time=tdiff_time,
+                                               tdiff_e_args=tdiff_e_args,
                                                ptest=ptest, strict_gs=strict_gs,
                                                logfile=logfile,
                                                log_level=log_level, step=step)
@@ -1387,7 +1609,8 @@ def plot_scan_and_beam(scan, beam, fattr="felv", rattr="belv", fhop_attr="fhop",
                        binc=ticker.MultipleLocator(3),
                        tinc=mdates.MinuteLocator(interval=15),
                        yinc=ticker.MultipleLocator(15), zinc=6, plot_title="",
-                       label_type="frac", make_plot=True, draw=True):
+                       label_type="frac", acolor="w", make_plot=True,
+                       draw=True):
     """Plot a specified attribute (elevation angle or virtual height) for the
     front and rear field-of-view, using a scan of beams and a single beam for
     a longer period of time.
@@ -1449,6 +1672,8 @@ def plot_scan_and_beam(scan, beam, fattr="felv", rattr="belv", fhop_attr="fhop",
         Plot title (default="")
     label_type : (str)
         Type of hop label to use (frac/decimal) (default="frac")
+    acolor : (str or tuple)
+        Background color for subplots (default="0.9" - light grey)
     make_plot : (boolian)
         Make plot (True) or just process data (False) (default=True)
     draw : (boolian)
@@ -1462,10 +1687,8 @@ def plot_scan_and_beam(scan, beam, fattr="felv", rattr="belv", fhop_attr="fhop",
         List of axis handles
     cb : (set)
         Output from colorbar
-
     """
     import davitpy.pydarn.radar as pyrad
-    rn = "plot_scan_and_beam"
 
     mkey = fhop_attr if mm.has_key(fhop_attr) else fhop_attr[1:]
     xpos = {7:1.1, 6:0.49, 5:0.35, 4:0.8, 3:0.7, 2:0.5, 1:0.0}
@@ -1604,6 +1827,12 @@ def plot_scan_and_beam(scan, beam, fattr="felv", rattr="belv", fhop_attr="fhop",
     rbax = plt.subplot(gb[:,1])
     ftax = plt.subplot(gt[0,:])
     rtax = plt.subplot(gt[1,:])
+
+    # Set the plot background color
+    fbax.set_axis_bgcolor(acolor)
+    rbax.set_axis_bgcolor(acolor)
+    ftax.set_axis_bgcolor(acolor)
+    rtax.set_axis_bgcolor(acolor)
 
     if zmin is None:
         zmin = min(np.nanmin(ftime), np.nanmin(rtime), np.nanmin(fbeam),
@@ -1788,9 +2017,10 @@ def plot_meteor_figure(fcolor="b", rcolor="m", stime=dt.datetime(2001,12,14),
                        region_hmin={"D":75.0,"E":115.0,"F":150.0},
                        rg_box=[2,5,10,20], vh_box=[50.0,50.0,50.0,150.0],
                        max_rg=[5,25,40,76], max_hop=3.0,
-                       ut_box=dt.timedelta(minutes=20.0), tdiff=list(),
-                       tdiff_e=list(), tdiff_time=list(), ptest=True, step=6,
-                       strict_gs=True, draw=True, beams=dict()):
+                       ut_box=dt.timedelta(minutes=20.0), tdiff=None,
+                       tdiff_args=list(), tdiff_e=None, tdiff_e_args=list(),
+                       ptest=True, step=6, strict_gs=True, draw=True,
+                       beams=dict()):
     """Plot comparing HWM14 neutral winds with the line-of-site velocity
     for two beams at Saskatoon
 
@@ -1856,14 +2086,27 @@ def plot_meteor_figure(fcolor="b", rcolor="m", stime=dt.datetime(2001,12,14),
     ut_box : (class dt.timedelta)
         Total width of universal time box to examine for backscatter FoV
         continuity. (default=20.0 minutes)
-    tdiff : (list)
-        A list of tdiff values (in microsec) or an empty list (to use the
-        hardware value) (default=list())
-    tdiff_e : (list)
-        A list containing the tdiff error (in microsec) or an empty list
-        (no elevation/virtual height error will be computed). (default=list())
-    tdiff_time : (list)
-        A list containing the starting time (datetimes) for each tdiff.
+    tdiff : (function or NoneType)
+        A function to retrieve tdiff values (in microsec) using the radar ID
+        number current datetime, and transmisson frequency as input.
+        Additional inputs may be specified using tdiff_args.  Example:
+        def get_tdiff(stid, time, tfreq, filename) { do things } return tdiff
+        tdiff=get_tdiff, tdiff_args=["tdiff_file"]
+        (default=None)
+    tdiff_args : (list)
+        A list specifying any arguements other than radar, time, and
+        transmission frequency to run the specified tdiff function.
+        (default=list())
+    tdiff_e : function or NoneType)
+        A function to retrieve tdiff error values (in microsec) using the radar
+        ID number, current datetime, and transmisson frequency as input.
+        Additional inputs may be specified using tdiff_e_args.  Example:
+        def get_tdiffe(stud, time, tfreq, filename) { do things } return tdiffe
+        tdiff_e=get_tdiffe, tdiff_e_args=["tdiff_file"]
+        (default=None)
+    tdiff_e_args : (list)
+        A list specifying any arguements other than radar, time, and
+        transmission frequency to run the specified tdiff_e function.
         (default=list())
     ptest : (boolian)
         Test to see if a propagation path is realistic (default=True)
@@ -1889,7 +2132,6 @@ def plot_meteor_figure(fcolor="b", rcolor="m", stime=dt.datetime(2001,12,14),
     beams : (dict)
         Dictionary with radar codes as keys for the dictionaries containing
         beams with the data used to create the plots
-
     """
     import davitpy.pydarn.plotting as plotting
     import davitpy.pydarn.radar as pyrad
@@ -1903,12 +2145,17 @@ def plot_meteor_figure(fcolor="b", rcolor="m", stime=dt.datetime(2001,12,14),
 
         Parameters
         ----------
-        p :
+        p : (float)
+            Power
+        verr : (float)
+            Doppler velocity error
+        werr : (float)
+            Spectral width error
 
-        verr :
-
-        werr :
-
+        Returns
+        --------
+        good : (bool)
+            True if fits characteristics for meteor, else false
         """
         # Initialize output
         good = False
@@ -1945,7 +2192,6 @@ def plot_meteor_figure(fcolor="b", rcolor="m", stime=dt.datetime(2001,12,14),
         Returns
         ---------
         bm_ap : (float)
-
         """
         ap_times = [dt.datetime(2001,12,1) + dt.timedelta(hours=i)
                     for i in range(744)]
@@ -2040,8 +2286,9 @@ def plot_meteor_figure(fcolor="b", rcolor="m", stime=dt.datetime(2001,12,14),
                                       region_hmin=region_hmin, rg_box=rg_box,
                                       vh_box=vh_box, max_rg=max_rg,
                                       max_hop=max_hop, ut_box=ut_box,
-                                      tdiff=tdiff, tdiff_e=tdiff_e,
-                                      tdiff_time=tdiff_time, ptest=ptest,
+                                      tdiff=tdiff, tdiff_args=tdiff_args,
+                                      tdiff_e=tdiff_e,
+                                      tdiff_e_args=tdiff_e_args, ptest=ptest,
                                       logfile=logfile, log_level=log_level,
                                       step=step)
 
@@ -2200,7 +2447,7 @@ def plot_map(ax, scan, hard=None, map_handle=None, fovs={1:None,-1:None},
              maxgates=None, fan_model='IS', model_alt=300.0, elv_attr="fovelv",
              alt_attr="vheight", dat_attr="v", fov_attr="fovflg", dmax=500.0,
              dmin=-500.0, dcolor=ccenter, lat_label=True, lon_label=True,
-             gscatter=True, draw=True):
+             gscatter=True, draw_map=True, plot_name=True, draw=True):
     """Plot a fov map
 
     Parameters
@@ -2263,7 +2510,6 @@ def plot_map(ax, scan, hard=None, map_handle=None, fovs={1:None,-1:None},
         Dictionary of fields-of-view
     hard : ( or NoneType)
         Hardware data (default=None)
-
     """
     import davitpy.pydarn.plotting as plotting
     import davitpy.pydarn.radar as pyrad
@@ -2332,7 +2578,7 @@ def plot_map(ax, scan, hard=None, map_handle=None, fovs={1:None,-1:None},
             fovs[ff] = pyrad.radFov.fov(site=hard, rsep=scan[0].prm.rsep,
                                         nbeams=hard.maxbeam, ngates=maxgates,
                                         bmsep=hard.bmsep, elevation=fan_elv,
-                                        altitude=fan_alt, model = fan_model,
+                                        altitude=fan_alt, model=fan_model,
                                         coords="geo", date_time=scan[0].time,
                                         fov_dir=fov_dir[ff])
 
@@ -2350,12 +2596,14 @@ def plot_map(ax, scan, hard=None, map_handle=None, fovs={1:None,-1:None},
                                      urcrnrlat=urlat, resolution="l")
 
     map_handle.ax = ax
-    map_handle.drawcoastlines(linewidth=0.5, color="0.6")
-    map_handle.fillcontinents(color="0.6", alpha=.1)
-    map_handle.drawmeridians(np.arange(-180.0, 180.0, 15.0),
-                             labels=[0,0,0,lon_label])
-    map_handle.drawparallels(np.arange(lllat, urlat+1.0, 10.0),
-                             labels=[lat_label,0,0,0])
+
+    if draw_map:
+        map_handle.drawcoastlines(linewidth=0.5, color="0.6")
+        map_handle.fillcontinents(color="0.6", alpha=.1)
+        map_handle.drawmeridians(np.arange(-180.0, 180.0, 15.0),
+                                 labels=[0,0,0,lon_label])
+        map_handle.drawparallels(np.arange(lllat, urlat+1.0, 10.0),
+                                 labels=[lat_label,0,0,0])
 
     # Add the field-of-view boundaries
     for ff in fovs.keys():
@@ -2368,7 +2616,7 @@ def plot_map(ax, scan, hard=None, map_handle=None, fovs={1:None,-1:None},
     # Add the radar location and name
     norm = mcolors.Normalize(vmin=dmin, vmax=dmax)
     plotting.mapOverlay.overlayRadar(map_handle, ids=scan[0].stid,
-                                     dateTime=scan[0].time, annotate=True,
+                                     dateTime=scan[0].time, annotate=plot_name,
                                      fontSize=16)
 
     # Add the data to each field-of-view

--- a/davitpy/pydarn/proc/fov/update_backscatter.py
+++ b/davitpy/pydarn/proc/fov/update_backscatter.py
@@ -32,7 +32,6 @@ beam_ut_struct_test         test for continuity in UT across beams
 Author: Angeline G. Burrell (AGB)
 Date: January 15, 2015
 Inst: University of Leicester (UoL)
-
 """
 
 # Import python packages
@@ -73,7 +72,6 @@ def assign_region(vheight, region_hmax={"D":115.0,"E":150.0,"F":900.0},
     -----------
     region : (str)
         one (or zero) character string denoting region
-
     """
     region = ""
     rpad = {"D":0.0, "E":0.0, "F":1.0}
@@ -113,7 +111,6 @@ def test_propagation(hop, vheight, dist,
     -----------
     good : (boolian)
         True if the path is realistic, False if it is not
-
     """
     good = True
 
@@ -409,332 +406,6 @@ def get_beam(radar_beams, nbeams):
 
     return beam, nbeams
 
-#---------------------------------------------------------------------------
-def calc_elv(beam, phi0_attr="phi0", phi0_e_attr="phi0_e", hard=None,
-             asep=None, ecor=None, phi_sign=None, tdiff=None, del_chi=None,
-             del_chif=0.0, alias=0.0, fov='front'):
-    """Calculate the elevation angle for observations along a beam at a radar
-
-    Parameters
-    -----------
-    beam : (class `pydarn.sdio.radDataTypes.beamData`)
-        Data for a single radar and beam along all range gates at a given time
-    hard : (class `pydarn.radar.radStruct.site` or NoneType)
-        Radar hardware data or None to load here (default=None)
-    asep : (float or NoneType)
-        Antenna separation in meters or None to calculate (default=None)
-    ecor : (float or NoneType)
-        Elevation correction in radians based on the altitude difference between
-        the radar and the interferometer or None to calculate (default=None)
-    phi_sign : (float or NoneType)
-        Sign change determined by the relative location of the interferometer
-        to the radar or None to calculate (default=None)
-    tdiff : (float or NoneType)
-        The relative time delay of the signal paths from the interferometer
-        array to the receiver and the main array to the reciver (microsec) or
-        None to use the value supplied by the hardware file (default=None)
-    del_chi : (float or NoneType)
-        The total phase shift caused by the cables and the filter in radians.
-        If None, will be calculated. (default=None)
-    del_chif : (float)
-        Additional phase shift in radians (default=0.0)
-    alias : (float)
-        Amount to offset the acceptable phase shifts by.  The default phase
-        shift range starts at the calculated max - 2 pi, any (positive) alias
-        will remove 2 pi from the minimum allowable phase shift. (default=0.0)
-    fov : (str)
-        'front' = Calculate elevation angles from front Field-of-View (fov);
-        'back' = Calculate elevation angle from back FoV. (default='front')
-    
-    Returns
-    --------
-    elv : (np.array)
-        A list of floats of the same size as the myBeam.fit.slist list,
-        containing the new elevation angles for each range gate or NaN if an
-        elevation angle could not be calculated
-    phase_amb: (np.array)
-        A list of integers containing the phase ambiguity integer used to
-        alias the elevation angles
-    hard : (class `pydarn.radar.radStruct.site` or NoneType)
-        Radar hardware data or None to load here (default=None)
-    asep : (float or NoneType)
-        Antenna separation in meters or None to calculate (default=None)
-    ecor : (float or NoneType)
-        Elevation correction in radians based on the altitude difference between
-        the radar and the interferometer or None to calculate (default=None)
-    phi_sign : (float or NoneType)
-        Sign change determined by the relative location of the interferometer
-        to the radar or None to calculate (default=None)
-
-    """
-    import davitpy.pydarn.sdio as sdio
-    import davitpy.pydarn.radar as pyrad
-
-    #-------------------------------------------------------------------------
-    # Test input
-    if not isinstance(beam, sdio.radDataTypes.beamData):
-        logging.error('the beam must be a beamData class')
-    assert(isinstance(phi0_attr, str) and hasattr(beam.fit, phi0_attr)), \
-        logging.error('the phase lag data is not in this beam')
-    assert(isinstance(hard, pyrad.site) or hard is None), \
-        logging.error('supply the hardware class or None')
-    assert(isinstance(asep, float) or asep is None), \
-        logging.error('the asep should be a float or NoneType')
-    assert(isinstance(ecor, float) or ecor is None), \
-        logging.error('the ecor should be a float or NoneType')
-    assert(isinstance(phi_sign, float) or phi_sign is None), \
-        logging.error('the phi_sign should be a float or NoneType')
-    assert(isinstance(tdiff, float) or tdiff is None), \
-        logging.error('the tdiff should be a float or NoneType')
-    assert(isinstance(del_chi, float) or del_chi is None), \
-        logging.error('the del_chi should be a float or NoneType')
-    assert(isinstance(del_chif, float)), \
-        logging.error('the del_chif should be a float')
-    assert(isinstance(alias, float)), \
-        logging.error('the alias number should be a float')
-    assert(isinstance(fov, str) and (fov.find("front") >= 0 or
-                                     fov.find("back") >= 0)), \
-        logging.error('the field-of-view must be "front" or "back"')
-
-    # Only use this if the interferometer data was stored during this scan
-    assert(beam.prm.xcf == 1), \
-        logging.error('no interferometer data at this time')
-
-    # Load the phase lag data
-    phi0 = getattr(beam.fit, phi0_attr)
-
-    # This method cannot be applied at Goose Bay or any other radar/beam that
-    # does not include phi0 in their FIT output
-    assert(phi0 is not None), \
-        logging.error('phi0 missing from rad {:d} beam {:d}'.format(beam.stid,
-                                                                    beam.bmnum))
-
-    # If possible, load the phase lag error data (not required to run)
-    if hasattr(beam.fit, phi0_e_attr):
-        phi0_e = getattr(beam.fit, phi0_e_attr)
-    else:
-        phi0_e = [1.0 for p in phi0]
-
-    #-------------------------------------------------------------------------
-    # Initialize output
-    elv = np.empty(shape=(len(phi0),), dtype=float) * np.nan
-    phase_amb = np.zeros(shape=(len(phi0),), dtype=int)
-
-    #-------------------------------------------------------------------------
-    # If desired, load the radar hardware data for the specified site and time
-    if hard is None:
-        hard = pyrad.site(radId=beam.stid, dt=beam.time)
-
-    # Set the proper angle sign based on whether this is backlobe or
-    # front lobe data
-    if fov.find("front") == 0:
-        back = 1.0
-    else:
-        back = -1.0
-
-    # If desired, overwrite the hardware value for tdiff
-    if tdiff is None:
-        tdiff = hard.tdiff
-
-    # If desired, calculate the radar specific variables
-    if asep is None or ecor is None or phi_sign is None:
-        # Calculate the elevation angle correction due to differences in
-        # altitude between the interferometer and the radar and determine
-        # whether the interferometer is in front or behind the radar
-        asep = np.sqrt(np.dot(hard.interfer, hard.interfer)) # meters
-        phi_sign = 1.0 if hard.interfer[1] > 0.0 else -1.0
-        ecor = phi_sign * hard.phidiff * np.arcsin(hard.interfer[2] / asep)
-
-    #-------------------------------------------------------------------------
-    # Calculate the beam-specific variables
-    #
-    # Phi is the beam direction off the radar boresite assuming an elevation
-    # angle of zero.  This is calculated by the hardware routine 'beamToAzim'
-    # located in pydarn.radar.radStruct
-    cos_phi = np.cos(np.radians(hard.beamToAzim(beam.bmnum) - hard.boresite))
-
-    # k is the wavenumber in radians per meter
-    k = 2.0 * np.pi * beam.prm.tfreq * 1.0e3 / scicon.c
-
-    # Calculate the phase shift due to the radar cables and any additional
-    # amount (due to the radar mode, etc.) unless a phase shift was supplied
-    if del_chi is None:
-        del_chi = -np.pi * beam.prm.tfreq * tdiff * 2.0e-3 - del_chif
-
-    # Find the maximum possible phase shift
-    chimax = phi_sign * k * asep * cos_phi
-    chimin = chimax - (alias + 1.0) * phi_sign * 2.0 * np.pi
-    
-    #-------------------------------------------------------------------------
-    # Calculate the elevation for each value of phi0
-    for i,p0 in enumerate(phi0):
-        #---------------------------------------------------------------------
-        # Use only data where the angular drift between signals is not
-        # identically zero with an error of zero, since this could either be a
-        # sloppy flag denoting no data or an actual measurement.
-        if p0 != 0.0 or phi0_e[i] != 0.0:
-            # Find the right phase.  This method works for both front and back
-            # lobe calculations, unlike the more efficient method used by RST
-            # in elevation.c:
-            # phi_tempf = phi0 + 2.0*np.pi* np.floor(((chimax+del_chi)-phi0)/
-            #                                       (2.0*np.pi))
-            # if phi_sign < 0.:
-            #     phi_tempf += 2.0 * np.pi
-            # cos_thetaf = (phi_tempf - del_chi) / (k * asep)
-            # sin2_deltaf = cos_phi**2 - cos_thetaf**2
-            #
-            # They both yield the same elevation for front lobe calculations
-            phi_temp = (back * (p0 - del_chi)) % (2.0 * np.pi)
-            amb_temp = -np.floor(back * (p0 - del_chi) / (2.0 * np.pi))
-
-            # Ensure that phi_temp falls within the proper limits
-            while phi_temp > max(chimax, chimin):
-                phi_temp += phi_sign * 2.0 * np.pi
-                amb_temp += phi_sign
-
-            while abs(phi_temp) < abs(chimin):
-                phi_temp += phi_sign * 2.0 * np.pi
-                amb_temp += phi_sign
-
-            #--------------------------
-            # Evaluate the phase shift
-            if phi_temp > max(chimax, chimin):
-                estr = "BUG ERROR: can't fix phase shift for beam "
-                estr = "{:s}{:d} [{:f} ".format(estr, beam.bmnum, phi_temp)
-                estr = "{:s}not between {:f},{:f} ".format(estr, chimin, chimax)
-                estr = "{:s}on {:} at range gate {:d}".format(estr, beam.time,
-                                                              beam.fit.slist[i])
-                logging.critical(estr)
-            else:
-                # Calcualte the elevation angle and set if realistic
-                cos_theta = phi_temp / (k * asep)
-                sin2_delta = cos_phi**2 - cos_theta**2
-
-                if sin2_delta >= 0.0:
-                    sin_delta = np.sqrt(sin2_delta)
-                    if sin_delta <= 1.0:
-                        new_elv = np.degrees(np.arcsin(sin_delta) + ecor)
-                        elv[i] = new_elv
-                        phase_amb[i] = int(amb_temp)
-
-    return elv, phase_amb, hard, asep, ecor, phi_sign
-
-#---------------------------------------------------------------------------
-def calc_virtual_height(beam, radius, elv=list(), elv_attr="elv", dist=list(),
-                        dist_attr="slist", dist_units=None):
-    """Calculate the virtual height for a specified backscatter distance and
-    elevation angle.  Specifying a single earth radius introduces additional
-    error into the resulting heights.  If the terrestrial radius at the radar
-    location is used, this error is on the order of 0.01-0.1 km (much smaller
-    than the difference between the real and virtual height).
-
-    Parameters
-    -----------
-    beam : (class `pydarn.sdio.radDataTypes.beamData`)
-        Data for a single radar and beam along all range gates at a given time
-    radius : (float)
-        Earth radius in km
-    elv : (list or numpy.array())
-        List containing elevation in degrees, or nothing to load the
-        elevation from the beam (default=list())
-    elv_attr : (string)
-        Name of beam attribute containing the elevation (default="elv")
-    dist : (list or numpy.array())
-        List containing the slant distance from the radar to the reflection
-        location of the backscatter, or nothing to load the distance from the
-        beam. (default=list())
-    dist_attr : (str)
-        Name of beam attribute containing the slant distance.  Be aware that if
-        the default is used, all heights returned will be for .5 hop propogation
-        paths.  (default="slist")
-    dist_units : (string or NoneType)
-        Units of the slant distance to backscatter location data.  May supply
-        "km", "m", or None.  None indicates that the distance is in range gate
-        bins. (default=None)
-    
-    Returns
-    --------
-    height : (numpy.array)
-        An array of floats of the same size as the myBeam.fit.slist list,
-        containing the new elevation angles for each range gate or NaN if an
-        elevation angle could not be calculated
-
-    """
-    import davitpy.pydarn.sdio as sdio
-
-    #---------------------------------
-    # Check the input
-    if not isinstance(beam, sdio.radDataTypes.beamData):
-        logging.error('the beam must be a beamData class')
-        return None
-
-    if not isinstance(radius, float):
-        logging.error('the radius must be a float')
-        return None
-
-    #---------------------------------
-    # Load elevation
-    if len(elv) == 0 or (len(dist) > 0 and len(elv) != len(dist)):
-        try:
-            elv = getattr(beam.fit, elv_attr)
-
-            if elv is None:
-                logging.error('no elevation available')
-                return None
-        except:
-            logging.error('no elevation attribute [{:s}]'.format(elv_attr))
-            return None
-
-    #---------------------------------
-    # Load the slant range/distance
-    if len(dist) == 0 or len(dist) != len(elv):
-        try:
-            dist = getattr(beam.fit, dist_attr)
-
-            if dist is None:
-                logging.error('no range/distance data availalbe')
-                return None
-
-            if len(dist) != len(elv):
-                logging.error('different number of range and elevation points')
-                return None
-        except:
-            logging.error('no range attribute [{:s}]'.format(dist_attr))
-            return None
-
-    if len(dist) == 0 or len(elv) == 0 or len(elv) != len(dist):
-        logging.error("unable to load matching elevation and distance lists")
-        return None
-
-    #---------------------------------------------------------------------
-    # Ensure that the range/distance (and error) are in km
-    if dist_units is None:
-        # Convert from range gates to km
-        dist = list(5.0e-10 * scicon.c * (np.array(dist) * beam.prm.smsep
-                                          + beam.prm.lagfr))
-    elif dist_units is "m":
-        # Convert from meters to km
-        dist = [d / 1000.0 for d in dist]
-    elif dist_units is not "km":
-        logging.error('unknown range unit [{:s}]'.format(dist_units))
-        return None
-
-    #-----------------------------------------------------------------------
-    # Cycle through the beams and elevations, calculating the virtual height
-    height = np.empty(shape=(len(dist),), dtype=float) * np.nan
-
-    for i,d in enumerate(dist):
-        if not np.isnan(elv[i]):
-            # Calculate height by assuming a spherical earth and solving the
-            # law of cosines for an obtuse triangle with sides radius,
-            # radius + height, and distance, where the angle between the side of
-            # length distance and radius + height is equal to 90 deg - elevation
-            hsqrt = np.sqrt(d**2 + radius**2 + 2.0 * d * radius
-                            * np.sin(np.radians(elv[i])))
-            height[i] = hsqrt - radius
-
-    return height
-
 #----------------------------------------------------------------------------
 def calc_distance(beam, rg_attr="slist", dist_units="km", hop=.5):
     """A routine to calculate distance in either meters or kilometers along the
@@ -772,7 +443,6 @@ def calc_distance(beam, rg_attr="slist", dist_units="km", hop=.5):
         containing the distance along the slant path from the radar to the first
         ionospheric reflection/refraction point given the specified propagation
         path for for each range gate. Returns None upon input error.
-
     """
     import davitpy.pydarn.sdio as sdio
 
@@ -787,7 +457,6 @@ def calc_distance(beam, rg_attr="slist", dist_units="km", hop=.5):
         estr = 'unknown units for distance [{:}]'.format(dist_units)
     elif not isinstance(hop, float) and hop > 0.0 and hop % 0.5 == 0.0:
         estr = 'unknown hop number [{:}]'.format(hop)
-
     else:
         # Load the range gate data
         try:
@@ -934,7 +603,6 @@ def select_beam_groundscatter(beam, dist, min_rg=10, max_rg=76, rg_box=5,
         ---------
         gflg : (boolean)
             New groundscatter flag
-
         """
         gflg = False
 
@@ -1012,7 +680,6 @@ def calc_frac_points(beam, dat_attr, dat_index, central_index, box,
         Total number of observations in the specified box.
 
     If there is an input error, exits with an exception
-
     """
     import davitpy.pydarn.sdio as sdio
 
@@ -1022,12 +689,12 @@ def calc_frac_points(beam, dat_attr, dat_index, central_index, box,
         logging.error("beam is not a beamData object")
     assert isinstance(dat_attr, str) and hasattr(beam.fit, dat_attr), \
         logging.error("beam does not contain attribute {:}".format(dat_attr))
-    assert(isinstance(dat_index, list) and isinstance(dat_index[0], int)), \
+    assert isinstance(dat_index, list) and isinstance(dat_index[0], int), \
         logging.error("dat_index is not a list of integers")
-    assert(box > 0), logging.error("box is not positive")
-    assert(isinstance(dat_min, type(box)) or dat_min is None), \
+    assert box > 0, logging.error("box is not positive")
+    assert isinstance(dat_min, type(box)) or dat_min is None, \
         logging.error("dat_min is of a different type is suspect")
-    assert(isinstance(dat_max, type(box)) or dat_max is None), \
+    assert isinstance(dat_max, type(box)) or dat_max is None, \
         logging.error("dat_max is of a different type is suspect")
 
     # Get the data list and ensure there is a value to search about
@@ -1075,7 +742,9 @@ def update_bs_w_scan(scan, hard, min_pnts=3,
                      region_hmin={"D":75.0,"E":115.0,"F":150.0},
                      rg_box=[2,5,10,20], rg_max=[5,25,40,76],
                      vh_box=[50.0,50.0,50.0,150.0], max_hop=3.0, tdiff=None,
-                     tdiff_e=None, ptest=True, strict_gs=False, step=6):
+                     tdiff_args=list(), tdiff_e=None, tdiff_e_args=list(),
+                     ptest=True, strict_gs=False, bmaz_e=0.0, boresite_e=0.0,
+                     ix_e=0.0, iy_e=0.0, iz_e=0.0, step=6):
     """Updates the propagation path, elevation, backscatter type, structure
     flag, and origin field-of-view (FoV) for all backscatter observations in
     each beam for a scan of data.  A full scan is not necessary, but if the
@@ -1109,15 +778,42 @@ def update_bs_w_scan(scan, hard, min_pnts=3,
         The maximum hop to consider for the range gate and height criteria
         specified by each list element in rg_box, srg_box, vh_box, and svh_box.
         (default=[3.0])
-    tdiff : (float or NoneType)
-        tdiff values (in microsec) or None (to use the hardware value)
+    tdiff : (function or NoneType)
+        A function to retrieve tdiff values (in microsec) using the radar ID
+        number, current datetime, and transmisson frequency as input.
+        Additional inputs may be specified using tdiff_args.  Example:
+        def get_tdiff(stid, time, tfreq, filename) { do things } return tdiff
+        tdiff=get_tdiff, tdiff_args=["tdiff_file"]
         (default=None)
-    tdiff_e : (float or NoneType)
-        tdiff error (in microsec) or None. (default=None)
+    tdiff_args : (list)
+        A list specifying any arguements other than radar, time, and
+        transmission frequency to run the specified tdiff function.
+        (default=list())
+    tdiff_e : (function or NoneType)
+        A function to retrieve tdiff error values (in microsec) using the radar
+        ID number, current datetime, and transmisson frequency as input.
+        Additionalinputs may be specified using tdiff_e_args.  Example:
+        def get_tdiffe(stid, time, tfreq, filename) { do things } return tdiffe
+        tdiff_e=get_tdiffe, tdiff_e_args=["tdiff_file"]
+        (default=None)
+    tdiff_e_args : (list)
+        A list specifying any arguements other than radar, time, and
+        transmission frequency to run the specified tdiff_e function.
+        (default=list())
     ptest : (boolian)
         Perform test to see if propagation modes are realistic? (default=True)
     strict_gs : (boolian)
         Remove indeterminately flagged backscatter (default=False)
+    bmaz_e : (float)
+        Error in beam azimuth in degrees (default=0.0)
+    boresite_e : (float)
+        Error in the boresite location in degrees (default=0.0)
+    ix_e : (float)
+        Error in the interferometer x coordinate in meters (default=0.0)
+    iy_e : (float)
+        Error in the interferometer y coordinate in meters (default=0.0)
+    iz_e : (float)
+        Error in the interferometer z coordinate in meters (default=0.0)
     step : (int)
         Integer denoting the number of processing steps to perform.  This should
         always be set to 6 (or greater) unless one wishes to reproduce the
@@ -1158,8 +854,7 @@ def update_bs_w_scan(scan, hard, min_pnts=3,
         beam.fit.gflg : updated : Flag indicating backscatter type
                                   (1=ground, 0=ionospheric, -1=indeterminate)
         beam.prm.tdiff : added : tdiff used in elevation (microsec)
-        beam.prm.tdiff_e : possibly added : tdiff error (microsec)
-
+        beam.prm.tdiff_e : added : tdiff error (microsec)
     """
     import davitpy.pydarn.sdio as sdio
     import davitpy.pydarn.radar as pyrad
@@ -1212,18 +907,6 @@ def update_bs_w_scan(scan, hard, min_pnts=3,
         logging.error('bad FoV virtual height box [{:}]'.format(vh_box))
         return None
 
-    if isinstance(tdiff, int):
-        tdiff = float(tdiff)
-    if not isinstance(tdiff, float) and tdiff is not None:
-        logging.error('tdiff must be a float')
-        return None
-
-    if isinstance(tdiff_e, int):
-        tdiff_e = float(tdiff_e)
-    if not isinstance(tdiff_e, float) and tdiff_e is not None:
-        logging.error('tdiff error values must be a float')
-        return None
-
     #-------------------------------------------------------------------------
     # Loading the beams into the output list, updating the distance,
     # groundscatter flag, virtual height, and propogation path
@@ -1258,7 +941,8 @@ def update_bs_w_scan(scan, hard, min_pnts=3,
             try:
                 beams[bnum] = scan.readRec()
             except:
-                logging.info("empty data pointer")
+                estr = "{:s} INFO: empty data pointer".format(rn)
+                logging.info(estr)
                 scan = None
 
         bnum += 1
@@ -1268,11 +952,31 @@ def update_bs_w_scan(scan, hard, min_pnts=3,
         elif beams[bnum-1] is None:
             bnum -= 1
         else:
+            # Update the beam parameters
+            if tdiff is None:
+                beams[bnum-1].prm.tdiff = None
+            else:
+                args = [beams[bnum-1].stid, beams[bnum-1].time,
+                        beams[bnum-1].prm.tfreq]
+                args.extend(tdiff_args)
+                beams[bnum-1].prm.tdiff = tdiff(*args)
+
+            if tdiff_e is None:
+                beams[bnum-1].prm.tdiff_e = None
+            else:
+                args = [beams[bnum-1].stid, beams[bnum-1].time,
+                        beams[bnum-1].prm.tfreq]
+                args.extend(tdiff_e_args)
+                beams[bnum-1].prm.tdiff_e = tdiff_e(*args)
+
+            # Update the beam fit values
             (beams[bnum-1], e, eerr, vh, verr, hh, rr,
-             nhard) = update_beam_fit(beams[bnum-1], hard=hard, tdiff=tdiff,
-                                      tdiff_e=tdiff_e, region_hmax=region_hmax,
+             nhard) = update_beam_fit(beams[bnum-1], hard=hard,
+                                      region_hmax=region_hmax,
                                       region_hmin=region_hmin, max_hop=max_hop,
-                                      ptest=ptest, strict_gs=strict_gs)
+                                      ptest=ptest, strict_gs=strict_gs,
+                                      bmaz_e=bmaz_e, boresite_e=boresite_e,
+                                      ix_e=ix_e, iy_e=iy_e, iz_e=iz_e)
 
             if e is None or nhard is None:
                 beams[bnum-1] = None
@@ -1379,7 +1083,7 @@ def update_bs_w_scan(scan, hard, min_pnts=3,
         rgbi = np.array(rgbi)
         rgsi = np.array(rgsi)
         rgrg = np.array(rgrg)
-        rgpath = set(["{:.1f}{:s}".format(rghop[ff][ii],reg)
+        rgpath = set(["{:.1f}{:s}".format(rghop[ff][ii], reg)
                       for ii,reg in enumerate(rgreg[ff])
                       if len(reg) == 1 and not np.isnan(rghop[ff][ii])
                       for ff in fov.values()])
@@ -1433,8 +1137,8 @@ def update_bs_w_scan(scan, hard, min_pnts=3,
                             estr = "insufficient beams to evaluate "
                             estr = "{:s}{:s} field-of-".format(estr, fov[ff])
                             estr = "{:s}view between [{:.0f}".format(estr, vmin)
-                            estr = "{:s}{-:.0f} km] ".format(estr, vmaxs[iv])
-                            estr = "{:s}at range gate {:d}".format(estr, r)
+                            estr = "{:s}-{:.0f} km] at ".format(estr, vmaxs[iv])
+                            estr = "{:s}range gate {:d}".format(estr, r)
                             logging.info(estr)
                         else:
                             # Initialize evaluation statistics to bad values
@@ -1498,7 +1202,7 @@ def update_bs_w_scan(scan, hard, min_pnts=3,
     inc_rg_box = 3.0
     for bi in range(bnum):
         if step < 3:
-            estr = "not testing backscatter unassigned after performing scan "
+            estr = "not testing backscatter unassigned after performing scan"
             logging.info("{:s}evaluation".format(estr))
             break
 
@@ -1544,8 +1248,8 @@ def update_bs_w_scan(scan, hard, min_pnts=3,
                         ilim += 1
 
                     if ilim >= len(rg_max):
-                        estr = "no guidelines provided for range gate ["
-                        logging.info("{:s}{:d}]".format(estr, rg))
+                        estr = "no guidelines provided for range gate "
+                        logging.info("{:s}[{:d}]".format(estr, rg))
                         continue
 
                     rg_half = (0.5 * (rg_box[ilim] + inc_rg_box))
@@ -1581,7 +1285,7 @@ def update_bs_w_scan(scan, hard, min_pnts=3,
                             # comparison continue without assigning a FoV flag
                             if not np.isnan(ihop) and len(ireg) == 1:
                                 estr = "not enough points to do single-beam "
-                                estr = "{:s}est for the ".format(estr)
+                                estr = "{:s}test for the ".format(estr)
                                 estr = "{:s}{:s} field-of".format(estr, fov[ff])
                                 estr = "{:s}-view for hop [".format(estr)
                                 estr = "{:s}{:.1f}{:s}".format(estr, ihop, ireg)
@@ -1639,17 +1343,17 @@ def update_bs_w_scan(scan, hard, min_pnts=3,
             break
 
         # Initialize the hop-dependent data
-        sihop = {ih:list() for ih in np.arange(0.5, max_hop+0.5, 0.5)}
-        bihop = {ih:list() for ih in np.arange(0.5, max_hop+0.5, 0.5)}
-        fovhop = {ih:list() for ih in np.arange(0.5, max_hop+0.5, 0.5)}
-        reghop = {ih:list() for ih in np.arange(0.5, max_hop+0.5, 0.5)}
+        sihop = {ih:list() for ih in np.arange(0.5, max_hop + 0.5, 0.5)}
+        bihop = {ih:list() for ih in np.arange(0.5, max_hop + 0.5, 0.5)}
+        fovhop = {ih:list() for ih in np.arange(0.5, max_hop + 0.5, 0.5)}
+        reghop = {ih:list() for ih in np.arange(0.5, max_hop + 0.5, 0.5)}
 
         min_range = hard.maxgate
         max_range = 0
         ilim = 0
 
         # Calculate the range gate limits
-        while(ilim < len(rg_max) and r >= rg_max[ilim]):
+        while ilim < len(rg_max) and r >= rg_max[ilim]:
             ilim += 1
 
         width = np.floor(0.5 * (rg_box[ilim] + inc_rg_box))
@@ -1824,12 +1528,16 @@ def update_bs_w_scan(scan, hard, min_pnts=3,
     return beams
 
 #-------------------------------------------------------------------------
-def update_beam_fit(beam, hard=None, tdiff=None, tdiff_e=None,
+def update_beam_fit(beam, hard=None,
                     region_hmax={"D":115.0,"E":150.0,"F":900.0},
                     region_hmin={"D":75.0,"E":115.0,"F":150.0}, max_hop=3.0,
-                    ptest=True, strict_gs=False):
+                    ptest=True, strict_gs=False, bmaz_e=0.0, boresite_e=0.0,
+                    ix_e=0.0, iy_e=0.0, iz_e=0.0):
     """Update the beam.fit and beam.prm class, updating and adding attributes
-    needed for common data analysis
+    needed for common data analysis.
+
+    Currently the earth radius error and slant distance error have no update
+    option through this routine and are identically zero.
 
     Parameters
     ------------
@@ -1838,11 +1546,6 @@ def update_beam_fit(beam, hard=None, tdiff=None, tdiff_e=None,
     hard : (class `pydarn.radar.radStruct.site` or NoneType)
        Hardware information for this radar.  Will load if not supplied.
        (default=None)
-    tdiff : (float or NoneType)
-        tdiff values (in microsec) or None (to use the hardware value)
-        (default=None)
-    tdiff_e : (float or NoneType)
-        tdiff error (in microsec) or None. (default=None)
     region_hmax : (dict)
         Maximum virtual heights allowed in each ionospheric layer.
         (default={"D":115.0,"E":150.0,"F":400.0})
@@ -1855,6 +1558,16 @@ def update_beam_fit(beam, hard=None, tdiff=None, tdiff_e=None,
         Perform test to see if propagation modes are realistic? (default=True)
     strict_gs : (boolian)
         Remove indeterminately flagged backscatter (default=False)
+    bmaz_e : (float)
+        Error in beam azimuth in degrees (default=0.0)
+    boresite_e : (float)
+        Error in the boresite location in degrees (default=0.0)
+    ix_e : (float)
+        Error in the interferometer x coordinate in meters (default=0.0)
+    iy_e : (float)
+        Error in the interferometer y coordinate in meters (default=0.0)
+    iz_e : (float)
+        Error in the interferometer z coordinate in meters (default=0.0)
 
     Returns
     ---------
@@ -1865,8 +1578,8 @@ def update_beam_fit(beam, hard=None, tdiff=None, tdiff_e=None,
         or adjusted attributes:
         beam.fit.gflg : updated : Flag indicating backscatter type
                                   (1=ground, 0=ionospheric, -1=indeterminate)
-        beam.prm.tdiff : added : tdiff used in elevation (microsec)
-        beam.prm.tdiff_e : possibly added : tdiff error (microsec)
+        beam.prm.tdiff : possibly updated : tdiff used in elevation (microsec)
+        beam.prm.tdiff_e : possibly updated : tdiff error (microsec)
     elvs : (dict)
         Elevation angles for the front "front" and rear "back" FoV
     elv_errs : (dict)
@@ -1885,11 +1598,12 @@ def update_beam_fit(beam, hard=None, tdiff=None, tdiff_e=None,
         Ionospheric regions for the front "front" and rear "back" FoV
     hard : (class `pydarn.radar.radStruct.site`)
         Radar hardware data for this scan
-
     """
     import davitpy.pydarn.sdio as sdio
     import davitpy.pydarn.radar as pyrad
     import davitpy.utils.geoPack as geo
+    import davitpy.pydarn.proc.fov.calc_elevation as ce
+    import davitpy.pydarn.proc.fov.calc_height as ch
 
     asep = None
     ecor = None
@@ -1913,18 +1627,6 @@ def update_beam_fit(beam, hard=None, tdiff=None, tdiff_e=None,
         logging.error('maximum hop must be a float greater than 0.5')
         return beam, None, None, None, None, None, None, None
 
-    if isinstance(tdiff, int):
-        tdiff = float(tdiff)
-    if not isinstance(tdiff, float) and tdiff is not None:
-        logging.error('tdiff must be a float or NoneType')
-        return beam, None, None, None, None, None, None, None
-
-    if isinstance(tdiff_e, int):
-        tdiff_e = float(tdiff_e)
-    if not isinstance(tdiff_e, float) and tdiff_e is not None:
-        logging.error('tdiff error must be a float or NoneType')
-        return beam, None, None, None, None, None, None, None
-
     if beam is None or beam.fit.slist is None or len(beam.fit.slist) <= 0:
         logging.warning("no fit data in beam at {:}".format(beam.time))
         return beam, None, None, None, None, None, None, None
@@ -1934,14 +1636,22 @@ def update_beam_fit(beam, hard=None, tdiff=None, tdiff_e=None,
     slist = getattr(beam.fit, "slist")
     elvs_aliased = {"front":[np.nan for s in slist],
                     "back":[np.nan for s in slist]}
+    elva_errs = {"front":[np.nan for s in slist],
+                 "back":[np.nan for s in slist]}
     elvs = {"front":[np.nan for s in slist], "back":[np.nan for s in slist]}
     elv_errs = {"front":[np.nan for s in slist], "back":[np.nan for s in slist]}
     vheights = {"front":[np.nan for s in slist], "back":[np.nan for s in slist]}
     vheights_aliased = {"front":[np.nan for s in slist],
                         "back":[np.nan for s in slist]}
+    vheighta_errs = {"front":[np.nan for s in slist],
+                     "back":[np.nan for s in slist]}
     vherrs = {"front":[np.nan for s in slist], "back":[np.nan for s in slist]}
     hops = {"front":[0.5 for s in slist], "back":[0.5 for s in slist]}
     regions = {"front":["" for s in slist], "back":["" for s in slist]}
+
+    # Initialize local constants
+    vmin = min(region_hmin.values())
+    vmax = max(region_hmax.values())
 
     #------------------------------------------------------------------------
     # Load the radar hardware data and calculate hardware specific variables,
@@ -1950,8 +1660,9 @@ def update_beam_fit(beam, hard=None, tdiff=None, tdiff_e=None,
         try:
             hard = pyrad.site(radId=beam.stid, dt=beam.time)
         except:
-            estr = "can't load hardware data for radar {:d}".format(beam.stid)
-            logging.warning("{:s} at {:}".format(estr, beam.time))
+            estr = "unable to load hardware data for radar "
+            estr = "{:s}{:d} at {:}".format(estr, beam.stid, beam.time)
+            logging.warning(estr)
             return beam, elvs, elv_errs, vheights, vherrs, None, None, None
 
     # Use the geodetic/geocentric conversion to get the terrestrial radius at
@@ -1997,25 +1708,29 @@ def update_beam_fit(beam, hard=None, tdiff=None, tdiff_e=None,
 
     # Calculate the elevation angles for the front and rear FoV, after
     # initializing the beam parameters with the supplied tdiff
-    if not hasattr(beam.prm, "tdiff"):
-        if tdiff is not None:
-            beam.prm.tdiff = tdiff
-        else:
-            beam.prm.tdiff = hard.tdiff
-    elif beam.prm.tdiff is None:
+    if not hasattr(beam.prm, "tdiff") or beam.prm.tdiff is None:
         beam.prm.tdiff = hard.tdiff
+
+    if not hasattr(beam.prm, "tdiff_e") or beam.prm.tdiff_e is None:
+        beam.prm.tdiff_e = np.nan
 
     for ff in ["front", "back"]:
         # Calculate the elevation
         try:
-            (elvs[ff], pamb, hard, asep, ecor,
-             phi_sign) = calc_elv(beam, hard=hard, asep=asep, ecor=ecor,
-                                  phi_sign=phi_sign, tdiff=beam.prm.tdiff,
-                                  fov=ff)
-            (elvs_aliased[ff], pamb, hard, asep, ecor,
-             phi_sign) = calc_elv(beam, hard=hard, asep=asep, ecor=ecor,
-                                  phi_sign=phi_sign, tdiff=beam.prm.tdiff,
-                                  alias=1.0, fov=ff)
+            (elvs[ff], elv_errs[ff], pamb, hard, asep, ecor,
+             phi_sign) = ce.calc_elv_w_err(beam, hard=hard, asep=asep,
+                                           ecor=ecor, phi_sign=phi_sign,
+                                           bmaz_e=bmaz_e, boresite_e=boresite_e,
+                                           ix_e=ix_e, iy_e=iy_e, iz_e=iz_e,
+                                           tdiff=beam.prm.tdiff,
+                                           tdiff_e=beam.prm.tdiff_e, fov=ff)
+            (elvs_aliased[ff], elva_errs[ff], pamb, hard, asep, ecor,
+             phi_sign) = ce.calc_elv_w_err(beam, hard=hard, asep=asep,
+                                           ecor=ecor, phi_sign=phi_sign,
+                                           bmaz_e=bmaz_e, boresite_e=boresite_e,
+                                           ix_e=ix_e, iy_e=iy_e, iz_e=iz_e,
+                                           tdiff=beam.prm.tdiff, alias=1.0,
+                                           fov=ff)
         except:
             estr = "can't get elevation for beam {:d} at {:}".format(beam.bmnum,
                                                                      beam.time)
@@ -2023,40 +1738,49 @@ def update_beam_fit(beam, hard=None, tdiff=None, tdiff_e=None,
             elvs[ff] = None
 
         if elvs[ff] is not None:
-            # Get the virtual height
-            vheights[ff] = calc_virtual_height(beam, radius, elv=elvs[ff],
-                                               dist=dist[ff], dist_units="km")
-            vheights_aliased[ff] = calc_virtual_height(beam, radius,
-                                                       elv=elvs_aliased[ff],
-                                                       dist=dist[ff],
-                                                       dist_units="km")
+            # Get the virtual height and virtual height error
+            vheights[ff], vherrs[ff] = \
+                ch.calc_virtual_height_w_err(beam, radius, elv=elvs[ff],
+                                             elv_e=elv_errs[ff], dist=dist[ff],
+                                             dist_e=[0.0 for dd in dist[ff]],
+                                             dist_units="km")
+            vheights_aliased[ff], vheighta_errs[ff] = \
+                ch.calc_virtual_height_w_err(beam, radius, elv=elvs_aliased[ff],
+                                             elv_e=elva_errs[ff], dist=dist[ff],
+                                             dist_e=[0.0 for dd in dist[ff]],
+                                             dist_units="km")
 
             # Test the virtual height
             for i,vh in enumerate(vheights[ff]):
-                if not np.isnan(vh) and vh < min(region_hmin.values()):
+                if not np.isnan(vh) and vh < vmin:
                     # This height is too low.  Replace it with a value corrected
                     # with a 2 pi alias or remove it from consideration for
                     # this FoV
-                    if vheights_aliased[ff][i] < min(region_hmin.values()):
+                    if vheights_aliased[ff][i] < vmin:
                         elvs[ff][i] = elvs_aliased[ff][i]
+                        elv_errs[ff][i] = elva_errs[ff][i]
                         vheights[ff][i] = vheights_aliased[ff][i]
+                        vherrs[ff][i] = vheighta_errs[ff][i]
                     else:
                         elvs[ff][i] = np.nan
                         vheights[ff][i] = np.nan
                     vh = vheights[ff][i]
+                vhe = vherrs[ff][i]
 
                 if not np.isnan(vh):
                     hop = hops[ff][i]
                     dd = dlist[i] * 0.5 / hop
                     ghop = True
-                    while vh > max(region_hmax.values()) and hop <= max_hop:
+                    while vh > vmax and hop <= max_hop:
                         # This height is too high.  Increase the hop
                         # number to acheive a realistic value
                         hop += 1.0
                         dd = dlist[i] * 0.5 / hop
-                        vh = calc_virtual_height(beam, radius,
-                                                 elv=[elvs[ff][i]], dist=[dd],
-                                                 dist_units="km")[0]
+                        vout = ch.calc_virtual_height_w_err(beam, radius, \
+                                    elv=[elvs[ff][i]], elv_e=[elv_errs[ff][i]],\
+                                    dist=[dd], dist_e=[0.0], dist_units="km")
+                        vh = vout[0][0]
+                        vhe = vout[1][0]
 
                     # Test the distance and hop to ensure that this
                     # mode is realistic
@@ -2069,31 +1793,39 @@ def update_beam_fit(beam, hard=None, tdiff=None, tdiff_e=None,
                         # If this is not a valid propagation path, attempt to
                         # use the elevation angle with a 2pi alias added
                         ea = elvs_aliased[ff][i]
+                        ee = elva_errs[ff][i]
                         vh = vheights_aliased[ff][i]
+                        vhe = vheighta_errs[ff][i]
                         hop = 1.0 if beam.fit.gflg[i] == 1 else 0.5
                         dd = dlist[i] * 0.5 / hop
-                        while vh > max(region_hmax.values()) and hop <= max_hop:
+                        while vh > vmax and hop <= max_hop:
                             # This height is too high.  Increase the hop
                             # number to acheive a realistic value
                             hop += 1.0
                             dd = dlist[i] * 0.5 / hop
-                            vh = calc_virtual_height(beam, radius, elv=[ea],
-                                                     dist=[dd],
-                                                     dist_units="km")[0]
+                            vout = ch.calc_virtual_height_w_err(beam, radius, \
+                                                                elv=[ea],
+                                                                elv_e=[ee], \
+                                    dist=[dd], dist_e=[0.0], dist_units="km")
+                            vh = vout[0][0]
+                            vhe = vout[1][0]
                         
-                        if vh >= min(region_hmin.values()):
+                        if vh >= vmin:
                             ghop = test_propagation(hop, vh, dd,
                                                     region_hmax=region_hmax,
                                                     region_hmin=region_hmin)
                     else:
                         ea = elvs[ff][i]
+                        ee = elv_errs[ff][i]
 
                     if hop <= max_hop and ghop:
                         # Update the lists
                         hops[ff][i] = hop
                         dist[ff][i] = dd
                         vheights[ff][i] = vh
+                        vherrs[ff][i] = vhe
                         elvs[ff][i] = ea
+                        elv_errs[ff][i] = ee
                         regions[ff][i] = assign_region(vh,
                                                        region_hmax=region_hmax,
                                                        region_hmin=region_hmin)
@@ -2117,9 +1849,10 @@ def update_backscatter(rad_bms, min_pnts=3,
                        region_hmin={"D":75.0,"E":115.0,"F":150.0},
                        rg_box=[2,5,10,20], vh_box=[50.0,50.0,50.0,150.0],
                        max_rg=[5,25,40,76], max_hop=3.0,
-                       ut_box=dt.timedelta(minutes=20.0), tdiff=list(),
-                       tdiff_e=list(), tdiff_time=list(), ptest=True,
-                       strict_gs=False, step=6):
+                       ut_box=dt.timedelta(minutes=20.0), tdiff=None,
+                       tdiff_args=list(), tdiff_e=None, tdiff_e_args=list(),
+                       ptest=True, strict_gs=False, bmaz_e=0.0, boresite_e=0.0,
+                       ix_e=0.0, iy_e=0.0, iz_e=0.0, step=6):
     """Updates the propagation path, elevation, backscatter type, and origin
     field-of-view (FoV) for all backscatter observations in each beam.  Scans
     of data are used to determine the origin field-of-view (FoV), but a full
@@ -2152,19 +1885,42 @@ def update_backscatter(rad_bms, min_pnts=3,
     ut_box : (class `dt.timedelta`)
         Total width of universal time box to examine for backscatter FoV
         continuity. (default=20.0 minutes)
-    tdiff : (list)
-        A list of tdiff values (in microsec) or an empty list (to use the
-        hardware value) (default=list())
-    tdiff_e : (list)
-        A list containing the tdiff error (in microsec) or an empty list
-        (no elevation/virtual height error will be computed). (default=list())
-    tdiff_time : (list)
-        A list containing the starting time (datetimes) for each tdiff.
+    tdiff : (function or NoneType)
+        A function to retrieve tdiff values (in microsec) using the radar ID
+        number current datetime, and transmisson frequency as input.
+        Additional inputs may be specified using tdiff_args.  Example:
+        def get_tdiff(stid, time, tfreq, filename) { do things } return tdiff
+        tdiff=get_tdiff, tdiff_args=["tdiff_file"]
+        (default=None)
+    tdiff_args : (list)
+        A list specifying any arguements other than radar, time, and
+        transmission frequency to run the specified tdiff function.
+        (default=list())
+    tdiff_e : function or NoneType)
+        A function to retrieve tdiff error values (in microsec) using the radar
+        ID number, current datetime, and transmisson frequency as input.
+        Additional inputs may be specified using tdiff_e_args.  Example:
+        def get_tdiffe(stud, time, tfreq, filename) { do things } return tdiffe
+        tdiff_e=get_tdiffe, tdiff_e_args=["tdiff_file"]
+        (default=None)
+    tdiff_e_args : (list)
+        A list specifying any arguements other than radar, time, and
+        transmission frequency to run the specified tdiff_e function.
         (default=list())
     ptest : (boolian)
         Test to see if a propagation path is realistic (default=True)
     strict_gs : (boolian)
         Remove indeterminately flagged backscatter (default=False)
+    bmaz_e : (float)
+        Error in beam azimuth in degrees (default=0.0)
+    boresite_e : (float)
+        Error in the boresite location in degrees (default=0.0)
+    ix_e : (float)
+        Error in the interferometer x coordinate in meters (default=0.0)
+    iy_e : (float)
+        Error in the interferometer y coordinate in meters (default=0.0)
+    iz_e : (float)
+        Error in the interferometer z coordinate in meters (default=0.0)
     step : (int)
         Integer denoting the number of processing steps to perform.  This should
         always be set to 6 (or greater) unless one wishes to reproduce the
@@ -2209,7 +1965,6 @@ def update_backscatter(rad_bms, min_pnts=3,
         beam.prm.tdiff_e : possibly added : tdiff error (microsec)
 
     If the input is incorrect, exits with an exception
-
     """
     import davitpy.pydarn.sdio as sdio
     import davitpy.pydarn.radar as pyrad
@@ -2222,12 +1977,12 @@ def update_backscatter(rad_bms, min_pnts=3,
         logging.error('need a list/array of beams or a radar data pointer')
     if isinstance(min_pnts, float):
         min_pnts = int(min_pnts)
-    assert(isinstance(min_pnts, int) and min_pnts >= 0), \
+    assert isinstance(min_pnts, int) and min_pnts >= 0, \
         logging.error('unknown point minimum [{:}]'.format(min_pnts))
     assert isinstance(region_hmin, dict) and min(region_hmin.values()) >= 0.0, \
-        logging.error('unknown min virtual heights [{:}]'.format(region_hmin))
+        logging.error("unknown minimum h' [{:}]".format(region_hmin))
     assert isinstance(region_hmax, dict), \
-        logging.error('unknown max virtual heights [{:}]'.format(region_hmax))
+        logging.error("unknown maximum h' [{:}]".format(region_hmax))
     assert((isinstance(rg_box, list) or isinstance(rg_box, np.ndarray))
            and min(rg_box) >= 1.0), \
         logging.error('range gate box is too small [{:}]'.format(rg_box))
@@ -2243,30 +1998,10 @@ def update_backscatter(rad_bms, min_pnts=3,
         logging.error('hop limits are unrealistic [{:}]'.format(max_hop))
     assert isinstance(ut_box, dt.timedelta) and ut_box.total_seconds() > 0.0, \
         logging.error('UT box must be a positive datetime.timdelta object')
-    assert(isinstance(tdiff, list) or isinstance(tdiff, np.ndarray)), \
-        logging.error('tdiff must be a list [{:}]'.format(tdiff))
-    assert isinstance(tdiff_e, list) or isinstance(tdiff_e, np.ndarray), \
-        logging.error('tdiff error values must be in a list [{:}]'.format( \
-                                                                    tdiff_e))
-    assert((isinstance(tdiff_time, list) or isinstance(tdiff_time, np.ndarray))
-           and len(tdiff_time) == len(tdiff)), \
-        logging.error('tdiff times must be in a list [{:}]'.format(tdiff_time))
     if isinstance(step, float):
         step = int(step)
     assert isinstance(step, int), logging.error('step flag must be an int')
 
-    #-----------------------------------------------------------------------
-    # Define local routines
-    def get_tdiff(td, bm_time):
-        ig = 0
-        while ig < len(tdiff_time) and bm_time < tdiff_time[ig]:
-            ig += 1
-
-        if ig >= len(tdiff_time):
-            return None
-
-        return td[ig]
-    # End local routine
     #-----------------------------------------------------------------------
     # Cycle through all the beams
     snum = 0
@@ -2279,8 +2014,7 @@ def update_backscatter(rad_bms, min_pnts=3,
     try:
         hard = pyrad.site(radId=bm.stid, dt=bm.time)
     except:
-        estr = "no data available in input rad structure"
-        logging.error(estr)
+        logging.error("no data available in input rad structure")
         return None
 
     #----------------------------------------------------------------
@@ -2326,10 +2060,12 @@ def update_backscatter(rad_bms, min_pnts=3,
                                          region_hmin=region_hmin,
                                          rg_box=rg_box, vh_box=vh_box,
                                          rg_max=max_rg, max_hop=max_hop,
-                                         tdiff=get_tdiff(tdiff,st),
-                                         tdiff_e=get_tdiff(tdiff_e,st),
-                                         ptest=ptest, strict_gs=strict_gs,
-                                         step=step)
+                                         tdiff=tdiff, tdiff_args=tdiff_args,
+                                         tdiff_e=tdiff_e,
+                                         tdiff_e_args=tdiff_e_args, ptest=ptest,
+                                         strict_gs=strict_gs, bmaz_e=bmaz_e,
+                                         boresite_e=boresite_e, ix_e=ix_e,
+                                         iy_e=iy_e, iz_e=iz_e, step=step)
 
                     if b is not None:
                         beams.extend(list(b))
@@ -2407,7 +2143,6 @@ def beam_ut_struct_test(rad_bms, min_frac=.10, frg_box=[5,8,13,23],
     beams : (dict)
         Dictionary containing lists of beams with updated FoV flags seperated
         by beam number.  The beam numbers are the dictionary keys
-
     """
     import davitpy.pydarn.sdio as sdio
     import davitpy.pydarn.radar as pyrad
@@ -2469,13 +2204,11 @@ def beam_ut_struct_test(rad_bms, min_frac=.10, frg_box=[5,8,13,23],
         return beams
 
     if not isinstance(reg_attr, str) or len(reg_attr) <= 0:
-        estr = 'badly formated region attribute [{:}]'.format(reg_attr)
-        logging.error(estr)
+        logging.error('badly formated region attribute [{:}]'.format(reg_attr))
         return beams
 
     if not isinstance(hop_attr, str) or len(reg_attr) <= 0:
-        estr = 'badly formated hop attribute [{:}]'.format(hop_attr)
-        logging.error(estr)
+        logging.error('badly formated hop attribute [{:}]'.format(hop_attr))
         return beams
 
     if not isinstance(fov_attr, str) or len(reg_attr) <= 0:

--- a/davitpy/pydarn/radar/__init__.py
+++ b/davitpy/pydarn/radar/__init__.py
@@ -16,6 +16,12 @@ pydarn.radar.radInfo
 pydarn.radar.radUtils
     misc. radar parameters (cpid...)
 
+Submodules
+-----------
+tdiff
+    Contains routines to estimate the hardware tdiff value for a specified
+    radar and frequency band
+
 """
 
 import logging
@@ -39,6 +45,11 @@ try:
     from radStruct import *
 except Exception as e:
     logging.exception(__file__+' -> pydarn.radar.radStruct: ', str(e))
+
+try:
+    import tdiff
+except Exception, e:
+    logging.exception('problem importing tdiff: ' + str(e))
 
 
 ####################################

--- a/davitpy/pydarn/radar/tdiff/__init__.py
+++ b/davitpy/pydarn/radar/tdiff/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# 2016 University of Leicester
+"""
+Subpackage
+----------
+pydarn.radar.tdiff
+    This subpackage contains routines to estimate the tdiff value for each
+    radar at a specified frequency band.
+
+Modules
+-------
+bscatter_distribution
+    Routines to find the distribution about a known locaiton
+calc_tdiff
+    Routines to select data and estimate tdiff
+rad_freqbands
+    Defines frequency bands for the radars
+simplex
+    Simplex minimizaiton routine
+"""
+
+import rad_freqbands
+import simplex
+import bscatter_distribution
+import calc_tdiff
+import test_tdiff

--- a/davitpy/pydarn/radar/tdiff/bscatter_distribution.py
+++ b/davitpy/pydarn/radar/tdiff/bscatter_distribution.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#---------------------------------------
+# bscatter_distribution.py, Angeline G. Burrell (AGB), UoL
+#
+# Comments: Functions that indicate how well backscatter fall about a specified
+#           location
+#-----------------------------------------------------------------------------
+"""This module contains the functions that indicate how well backscatter fall
+about a specified location
+
+Functions
+------------------------------------------------------------------------------
+lat_distribution     Calculate the deviation about a specified latitude
+vheight_distribution Calculate the deviation about a specified virtual height
+distribution_min     Optimize distribution of backscatter about a specified
+                     location
+------------------------------------------------------------------------------
+
+References
+------------------------------------------------------------------------------
+A.G. Burrell et al. (2016) submitted to Radio Science doi:xxx
+------------------------------------------------------------------------------
+"""
+import numpy as np
+
+#---------------------------------------------------------------------------
+def lat_distribution(tdiff, ref_lat, hard, asep, phi_sign, ecor, phi0, phi0e,
+                     fovflg, cos_phi, tfreq, bmnum, dist):
+    '''Returns the squared sum of the difference between the mean and the
+    specified latitude and the standard deviation of the backscatter latitudes
+
+    Parameters
+    -----------
+    tdiff : (float)
+        tdiff in microseconds
+    ref_lat : (float)
+        reference latitude in degrees
+    hard : (class davitpy.pydarn.radar.radStruct.site)
+        radar hardware data
+    asep : (float)
+        antenna seperation in m
+    phi_sign : (float)
+        states whether or not the interferometer is in front of the radar
+    ecor : (float)
+        correction to elevation angle based on interferometer alt
+    phi0 : (list)
+        phase lags in radians
+    phi0e : (list)
+        phase lag errors in radians
+    fovflg : (list)
+        field-of-view flags
+    cos_phi : (list)
+        cos of azimuthal angles
+    tfreq : (list)
+        transmission frequencies in kHz
+    bmnum : (list)
+        beam number
+    dist : (list)
+        slant distance from radar to ionospheric reflection point in km
+
+    Returns
+    ---------
+    ff : (float)
+        standard deviation of the latitude distribution
+
+    Notes
+    -------
+    Calculates equation 3 in Burrell et al. (2016)
+    '''
+    import davitpy.utils.geoPack as geo
+    import davitpy.pydarn.proc.fov.calc_elevation as celv
+    # Ensure that TDIFF is a single number and not a list or array element
+    try:
+        len(tdiff)
+        tdiff = tdiff[0]
+    except:
+        pass
+
+    if not isinstance(tdiff, float):
+        tdiff = float(tdiff)
+
+    # Calculate the elevation and latitude
+    try:
+        # elevation is in radians
+        elv = np.array(celv.calc_elv_list(phi0, phi0e, fovflg, cos_phi, tfreq,
+                                          asep, ecor, phi_sign, tdiff)) 
+        loc = geo.calcDistPnt(hard.geolat, hard.geolon, hard.alt,
+                              az=hard.beamToAzim(np.array(bmnum)),
+                              el=np.degrees(elv), dist=np.array(dist))
+        lat = loc['distLat'][~np.isnan(loc['distLat'])] # Remove nan
+
+        #--------------------------------------------------------------------
+        # When the distribution is approximately gaussian, the error depends
+        # on the location of the peak and the amount of spread.  Testing the
+        # standard deviation prevents the formation of a bimodal distribution
+        # who each flank the desired location
+        #
+        # Sum the errors
+        ff = np.nan if len(lat) == 0 else np.sqrt((lat.mean() - ref_lat)**2 +
+                                                  lat.std()**2)
+    except:
+        ff = np.nan
+
+    # Return the square root of the summed squared errors
+    return ff
+
+#---------------------------------------------------------------------------
+def vheight_distribution(tdiff, ref_height, radius, asep, phi_sign, ecor, phi0,
+                         phi0e, fovflg, cos_phi, tfreq, dist):
+    '''Returns the squared sum of the difference between the mean and the
+    specified height and the standard deviation of the backscatter heights
+
+    Parameters
+    -----------
+    tdiff : (float)
+        tdiff in microseconds
+    ref_height : (float)
+        reference altitude in km
+    radius : (float)
+        earth radius in km
+    asep : (float)
+        antenna seperation in m
+    phi_sign : (float)
+        states whether or not the interferometer is in front of the radar
+    ecor : (float)
+        correction to elevation angle based on interferometer alt
+    phi0 : (list)
+        phase lags in radians
+    phi0e : (list)
+        phase lag errors in radians
+    fovflg : (list)
+        field-of-view flags
+    cos_phi : (list)
+        cos of azimuthal angles
+    tfreq : (list)
+        transmission frequencies in kHz
+    dist : (list)
+        slant distance from radar to ionospheric reflection point in km
+
+    Returns
+    ---------
+    ff : (float)
+        standard deviation of the height distribution
+
+    Notes
+    -------
+    Calculates equation 3 in Burrell et al. (2016)
+    '''
+    import davitpy.pydarn.proc.fov.calc_elevation as celv
+    
+    # Ensure that TDIFF is a single number and not a list or array element
+    try:
+        len(tdiff)
+        tdiff = tdiff[0]
+    except:
+        pass
+
+    if not isinstance(tdiff, float):
+        tdiff = float(tdiff)
+
+    # Calculate the elevation and virtual height
+    try:
+        elv = celv.calc_elv_list(phi0, phi0e, fovflg, cos_phi, tfreq, asep,
+                                 ecor, phi_sign, tdiff) # in radians
+        heights = [np.sqrt(dd**2 + radius**2 + 2.0 * dd * radius *
+                           np.sin(elv[di])) - radius
+                   for di,dd in enumerate(dist)
+                   if not np.isnan(dd) and not np.isnan(elv[di])] # in km
+
+        #--------------------------------------------------------------------
+        # When the distribution is approximately gaussian, the error depends
+        # on the location of the peak and the amount of spread.  Testing the
+        # standard deviation prevents the formation of a bimodal distribution
+        # who each flank the desired location
+        #
+        # Sum the errors
+        ff = np.nan if len(heights) == 0 else np.sqrt((np.mean(heights) -
+                                                       ref_height)**2
+                                                      + np.std(heights)**2)
+    except:
+        ff = np.nan
+
+    # Return the square root of the summed squared errors
+    return ff
+
+
+#---------------------------------------------------------------------------
+def distribution_min(tdiff, ref_loc, loc_args, loc_func, func_tol,
+                     tdiff_tol=1.0e-4, tperiod=np.nan, maxiter=2000):
+    '''Finds the minimum of the locaiton distribution about an ideal location
+
+    Parameters
+    -----------
+    tdiff : (float)
+        initial tdiff in microseconds
+    ref_loc : (float)
+        reference location
+    loc_args : (tuple)
+        A set containing the values for each backscatter measurement needed to
+        calculate the location of the scattering point.  For example, latitude
+        requires:
+        (hard, asep, phi_sign, ecor, phi0, phi0e, fovflg, cos_phi, tfreq)
+    loc_func : (function)
+        Function that describes the goodness of the backscatter distribution
+        about the reference location, where a lower value indicates a better fit
+    func_tol : (float)
+        Level of significance between minima in units of location
+    tdiff_tol : (float)
+        Level of significance for resulting tdiff in microseconds.
+        (default=1.0e-4)
+    tperiod : (float)
+        If this is a cyclical function, include the period where another
+        minimum is expected.  If not, use NaN (default=np.nan)
+    maxiter : (int)
+        Maximum number of iterations to allow in estimation process.
+        (default=2000)
+
+    Returns
+    ---------
+    new_tdiff : (float)
+        New tdiff estimate in microseconds
+    miter : (int)
+        Number of iterations needed to estimate tdiff
+    res : (tuple)
+        Results from the successful simplex minimization run
+    '''
+    import davitpy.pydarn.radar.tdiff.simplex as simplex
+
+    # Perform the minimization using the Nelder-Mead Simplex method
+    tdiff1, mi1, res1 = simplex.rigerous_simplex(tdiff, (ref_loc,) + loc_args,
+                                                 loc_func, tol=tdiff_tol,
+                                                 maxiter=maxiter)
+
+    if np.isnan(tperiod) or np.isnan(tdiff1) or mi1 >= maxiter:
+        # If the function is not cyclical, or a minima could not be found,
+        # return with the result
+        return tdiff1, mi1, res1
+
+    # If this is a cyclical function, perturb the initial guess by one period
+    # Choose the direction that should find an estimate that brackets the
+    # initial guess
+    tsign = np.sign(tdiff - tdiff1)
+    new_sign = tsign
+    mi2 = mi1
+    tdiff2 = tdiff1
+    while np.sign(new_sign) == tsign and mi2 < maxiter and not np.isnan(tdiff2):
+        tdiff2, mi, res2 = simplex.rigerous_simplex(tdiff1+new_sign*tperiod,
+                                                    (ref_loc,) + loc_args,
+                                                    loc_func, tol=tdiff_tol,
+                                                    maxiter=maxiter)
+        mi2 += mi
+        if not np.isnan(tdiff2):
+            new_sign = np.sign(tdiff - tdiff2)
+            if new_sign == tsign:
+                # We have found a minima closer to the initial guess, but not
+                # bracketing the initial guess
+                tdiff1 = tdiff2
+                mi1 = mi2
+                res1 = res2
+
+    # If a bracketing minima could not be found, return the first minima
+    if np.isnan(tdiff2) or mi2 >= maxiter:
+        return tdiff1, mi1, res1
+
+    # Ensure that there is not a thrid minima of equal signicance close to the
+    # initial guess
+    if tdiff1 < tdiff2:
+        a = tdiff1
+        c = tdiff2
+        fa = res1['fun']
+        fc = res2['fun']
+    else:
+        a = tdiff2
+        c = tdiff1
+        fa = res2['fun']
+        fc = res1['fun']
+
+    # If the two minima bracket the initial guess, there may be another minima
+    # that is closer to the initial guess
+    if a < tdiff and tdiff < c:
+        fb = loc_func(tdiff, *((ref_loc,) + loc_args))
+
+        # Move upper and lower limits to exclude the identified minima
+        while fb >= fa and tdiff - a > tdiff_tol:
+            a = tdiff - 0.5 * (tdiff - a)
+            fa = loc_func(a, *((ref_loc,) + loc_args))
+        
+        while fb >= fc and c - tdiff > tdiff_tol:
+            c = tdiff + 0.5 * (c - tdiff)
+            fc = loc_func(c, *((ref_loc,) + loc_args))
+
+        # But we won't bother messing about with minimization at this point.
+        # Now that the problem is constrained, make a list with tdiff
+        # incrimenting at the rate of the tolerence
+        if a <= tdiff and tdiff <= c:  
+            x = np.arange(a, c, tdiff_tol*1.0e-1)
+        else:
+            x = []
+
+        # Of course the tdiff correction may be really close to tdiff already.
+        # Only continue if there was enough of a difference between the two
+        # bracketing points to provide a range of points to calcuate a minima.
+        if len(x) > 1:
+            y = [loc_func(xx, *((ref_loc,) + loc_args)) for xx in x]
+            ymin = min(y)
+            xx = y.index(ymin)
+            # A minima between the two previously found was located.
+            if abs(res1['fun'] - ymin) <= func_tol:
+                # This minima is equally significant.  Keep it if it is
+                # closer to the initial guess than the first minima
+                if abs(tdiff1 - tdiff) > abs(x[xx] - tdiff):
+                    tdiff1 = x[xx]
+                    mi1 = maxiter - 1
+                    res1 = {'status':0, 'nfev':len(y), 'success':True,
+                            'fun':ymin, 'x':x[xx], 'message':'Found from list',
+                            'nit':mi1}
+            elif ymin < res1['fun']:
+                # This minima is more significant.  Keep it
+                mi1 = maxiter - 1
+                res1 = {'status':0, 'nfev':len(y), 'success':True, 'fun':ymin,
+                        'x':x[xx], 'message':'Found from list', 'nit':mi1}
+                return x[xx], mi1, res1
+
+    # See if the remaining minima are equally significant.  If they are pick the
+    # one closest to the original guess.  Otherwise choose the deepest minima
+    if abs(res1['fun'] - res2['fun']) <= func_tol:
+        # Check to see if the difference between the distances between the
+        # tdiff estimate and the initial guess are significant.  If they are not
+        # then choose the tdiff with the lowest function value.  If they are
+        # significant, than choose the value closest to the inital guess
+        diff1 = abs(tdiff1 - tdiff)
+        diff2 = abs(tdiff2 - tdiff)
+
+        if abs(diff1 - diff2) <= tdiff_tol:
+            if res1['fun'] <= res2['fun']:
+                return tdiff1, mi1, res1
+            else:
+                return tdiff2, mi2, res2
+        else:
+            if diff1 <= diff2:
+                return tdiff1, mi1, res1
+            else:
+                return tdiff2, mi2, res2
+    elif res1['fun'] < res2['fun']:
+        return tdiff1, mi1, res1
+    else:
+        return tdiff2, mi2, res2

--- a/davitpy/pydarn/radar/tdiff/calc_tdiff.py
+++ b/davitpy/pydarn/radar/tdiff/calc_tdiff.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#---------------------------------------
+# calc_tdiff.py, Angeline G. Burrell (AGB), UoL
+#
+# Comments: Function to estimate tdiff
+#-----------------------------------------------------------------------------
+"""This module contains routines to estimate tdiff from backscatter at a known
+location
+
+Functions
+-------------------------------------------------------------------------------
+calc_tdiff       Calculate tdiff by minimizing the distribution about a location
+select_bscatter  Select appropriate backscatter
+-------------------------------------------------------------------------------
+
+References
+------------------------------------------------------------------------------
+A.G. Burrell et al. (2016) submitted to Radio Science doi:xxx
+------------------------------------------------------------------------------
+"""
+import numpy as np
+import logging
+
+def calc_tdiff(init_tdiff, ref_loc, ref_err, loc_args, loc_func, func_tol,
+               tdiff_tol=1.0e-4, tperiod=np.nan, maxiter=2000):
+    ''' Calculate tdiff by minimizing the distribution about a location
+
+    Parameters
+    ----------
+    init_tdiff : (float)
+        Initial tdiff guess (recommend using tdiff from hdw files)
+    ref_loc : (float)
+        Reference location (e.g. latitude or altitude)
+    ref_err : (float)
+        Uncertainty in reference location
+    loc_args : (list)
+        List of arguements needed to calculate the location, in the correct
+        order to use as input for the location function.  For example, latitude
+        requires:
+        (hard, asep, phi_sign, ecor, phi0, phi0e, fovflg, cos_phi, tfreq)
+    loc_func : (function)
+        Function that describes the goodness of the backscatter distribution
+        about the reference location, where a lower value indicates a better fit
+    func_tol : (float)
+        Level of significance between minima in units of location
+    tdiff_tol : (float)
+        Level of significance for resulting tdiff in microseconds.
+        (default=1.0e-4)
+    tperiod : (float)
+        If this is a cyclical function, include the period where another
+        minimum is expected.  If not, use NaN (default=np.nan)
+    maxiter : (int)
+        Maximum number of iterations to allow in estimation process.
+        (default=2000)
+
+    Returns
+    -----------
+    tdiff : (float)
+        tdiff in microseconds
+    terr : (float)
+        uncertainty in tdiff in microseconds
+    miter : (int)
+        Number of iterations needed to estimate tdiff
+    res : (tuple)
+        Results from the successful simplex minimization run
+    '''
+    import bscatter_distribution as bdist
+
+    terr = np.nan
+
+    # Estimate tdiff:
+    tdiff, miter, res = bdist.distribution_min(init_tdiff, ref_loc, loc_args,
+                                               loc_func, func_tol,
+                                               tdiff_tol=tdiff_tol,
+                                               tperiod=tperiod, maxiter=maxiter)
+    if np.isnan(tdiff):
+        return tdiff, terr, miter, res
+
+    # Find the tdiff uncertainty by calculating tdiff with
+    # ref_lat +/- ref_err and taking the larger of the two
+    thigh, eiter, eres = bdist.distribution_min(init_tdiff, ref_loc + ref_err,
+                                                loc_args, loc_func, func_tol,
+                                                tdiff_tol=tdiff_tol,
+                                                tperiod=tperiod,
+                                                maxiter=maxiter)
+
+    tlow, eiter, eres = bdist.distribution_min(init_tdiff, ref_loc - ref_err,
+                                               loc_args, loc_func, func_tol,
+                                               tdiff_tol=tdiff_tol,
+                                               tperiod=tperiod, maxiter=maxiter)
+    if not np.isnan(thigh):
+        terr = abs(thigh - tdiff)
+    if not np.isnan(tlow):
+        if np.isnan(terr) or terr < abs(tlow - tdiff):
+            terr = abs(tlow - tdiff)
+
+    return tdiff, terr, miter, res
+
+def select_bscatter(beams, ret_attrs, radcp, tband, bnum, min_power=0.0,
+                    min_rg=0, max_rg=75, fovflg=None, gflg=None, stimes=list(),
+                    etimes=list()):
+    '''Sample selection routine for heater backscatter
+
+    Parameters
+    ------------
+    beams : (list or np.ndarray)
+        List or array of beam class objects, or scan class object from a
+        single radar
+    ret_attrs : (list of strings)
+        List of desired attributes to return
+    radcp : (int)
+        Desired radar program mode
+    tband : (int)
+        Desired radar transmission frequency band
+    bnum : (int)
+        Desired radar beam number
+    min_power : (float)
+        Minimum allowed power (dB) (default=0.0)
+    min_rg : (int)
+        Minimum allowed range gate (default=0)
+    max_rg : (int)
+        Maximum allowed range gate (default=75)
+    fovflg : (int)
+        Desired field-of-view or None to ignore (default=None)
+    gflg : (int)
+        Desired type of backscatter or None to ignore (default=None)
+    stimes : (list)
+        List of allowed starting time periods (default=[])
+    etimes : (list)
+        List of allowed ending time periods (default=[])
+
+    Returns
+    ----------
+    ret_data : (dict of lists)
+        Dictionary containing lists of desired return attributes
+    '''
+    import rad_freqbands
+
+    # Define the local routines
+    def good_fov(fovflg, bfit, i):
+        if fovflg is None:
+            return True
+        else:
+            if hasattr(bfit, "fovflg"):
+                fitflg = getattr(bfit, "fovflg")
+                if fitflg is not None and fitflg[i] == fovflg:
+                    return True
+        return False
+            
+    def good_time(stimes, etimes, btime):
+        if len(stimes) > 0:
+            for i,ss in enumerate(stimes):
+                if ss <= btime and  btime <= etimes[i]:
+                    return True
+        else:
+            return True
+        return False
+                
+    # Initialize output
+    ret_data = {rkey:list() for rkey in ret_attrs}
+
+    # Begin evaluating beam data
+    rad_tfreq = None
+
+    for beam in beams:
+        # Use the first beam to define the frequency band object
+        if rad_tfreq is None:
+            rad_tfreq = rad_freqbands.radFreqBands(beam.stid)
+
+            # Test to see if the frequency band is defined
+            if len(rad_tfreq.tbands) < tband:
+                logging.warn("undefined frequency band [{:}]".format(tband))
+                return ret_data
+
+        # Identify acceptable backscatter for this beam
+        if(hasattr(beam, "fit") and beam.cp == radcp and beam.bmnum == bnum
+           and hasattr(beam, "prm") and
+           tband == rad_tfreq.get_tfreq_band_num(beam.prm.tfreq)):
+            igood = [i for i,p in enumerate(beam.fit.p_l) if p >= min_power and
+                     min_rg <= beam.fit.slist[i] and max_rg >= beam.fit.slist[i]
+                     and good_fov(fovflg, beam.fit, i) and
+                     (gflg is None or beam.fit.gflg[i] == gflg)
+                     and good_time(stimes, etimes, beam.time)]
+
+            if len(igood) > 0:
+                # Assign values for each requested data type, padding with
+                # NaN if the key or values aren't available
+                for rkey in ret_data.keys():
+                    if hasattr(beam, rkey):
+                        # Add beam attribute
+                        rdata = getattr(beam, rkey)
+                        ret_data[rkey].extend([rdata for i in igood])
+                    elif hasattr(beam.fit, rkey):
+                        # Add fit attribute
+                        rdata = getattr(beam.fit, rkey)
+                        if rdata is not None:
+                            ret_data[rkey].extend([rdata[i] for i in igood])
+                        else:
+                            ret_data[rkey].extend([np.nan for i in igood])
+                    elif hasattr(beam.prm, rkey):
+                        # Add parameter attribute
+                        rdata = getattr(beam.prm, rkey)
+                        ret_data[rkey].extend([rdata for i in igood])
+                    else:
+                        # Pad unavailable attribute
+                        ret_data[rkey].extend([np.nan for i in igood])
+
+    return ret_data

--- a/davitpy/pydarn/radar/tdiff/rad_freqbands.py
+++ b/davitpy/pydarn/radar/tdiff/rad_freqbands.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#-----------------------------------------------------------------------------
+# rad_freqbands.py, Angeline G. Burrell (AGB), UoL
+#
+# Comments: Routines to define and retrieve frequency bands for the SuperDARN
+#           radars.  These would be better saved and accessed through a table,
+#           so as to allow for temporal updates.
+#-----------------------------------------------------------------------------
+'''Define and retrieve transmission frequency bands for the SuperDARN radars.
+
+Parameters
+----------------------------------------------------------------------------
+rad_band_num : (dict)
+rad_min : (dict)
+rad_max : (dict)
+id_to_code : (dict)
+---------------------------------------------------------------------------
+
+Classes
+----------------------------------------------------------------------------
+radFreqBands
+----------------------------------------------------------------------------
+
+Moduleauthor
+------------
+Angeline G. Burrell (AGB), 25 July 2016, University of Leicester (UoL)
+'''
+import logging
+
+# Define the frequency bands for different radars
+#
+# The radar band numbers allow new frequency bands to be added in numerical
+# order whilst maintaining backward compatibility
+rad_band_num = {
+    'ade':[0,1,2,3,4,5,6,7,8],
+    'adw':[0,1,2,3,4,5,6,7,8],
+    'cly':[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,
+           25,26],
+    'han': [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],
+    'inv': [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,
+            25,26,27],
+    'mcm':[0,1,2,3,4,5,6,7,8],
+    'pgr': [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,
+            25,26,27],
+    'pyk': [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19],
+    'rkn': [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,
+            25,26,27],
+    'sas': [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24],
+    'sto': [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,
+            23,24,25,26],}
+
+# Radar frequencies saved in kHz
+rad_min = {
+    'ade':[10400, 10900, 12000, 13000, 14500, 15000, 16000, 17000, 18000],
+    'adw':[10400, 10900, 12000, 13000, 14500, 15000, 16000, 17000, 18000],
+    'cly':[8000, 8500, 9000, 9500, 10000, 10500, 11000, 11500, 12000, 12500,
+           13000, 13469, 13929, 14500, 15040, 15500, 16000, 16500, 17000, 17500,
+           18000, 18500, 19000, 19500, 20040, 20500],
+    'han':[8305, 8965, 9900, 11075, 11550, 12370, 13200, 15010, 16210, 16555,
+           17970, 18850, 19415, 19705, 19800],
+    'inv':[8000, 8500, 9000, 9500, 10000, 10500, 11000, 11500, 12000, 12500,
+           13000,  13500, 14000, 14500, 15000, 15500, 16000, 16500, 17000,
+           17500, 18000, 18500, 19000,19500,20000,20500,21000,21500],
+    'mcm':[10100, 10700, 11400, 12500, 13700, 14400, 15200, 17000, 18400],
+    'pgr':[8000, 8500, 9000, 9500, 10000, 10500, 11000, 11500, 12000, 12500,
+           13000,  13500, 14000, 14500, 15000, 15500, 16000, 16500, 17000,
+           17500, 18000, 18500, 19000,19500,20000,20500,21000,21500],
+    'pyk':[8000, 8430, 8985, 10155, 10655, 11290, 11475, 12105, 12305, 12590,
+           13360, 13875, 14400, 15805, 16500, 16820, 18175, 18835, 19910,
+           10155],
+    'rkn':[8000, 8500, 9000, 9500, 10000, 10500, 11000, 11500, 12000, 12500,
+           13000,  13419, 14000, 14500, 15000, 15500, 16000, 16500, 17000,
+           17500, 18000, 18500, 19000,19500,20000,20500,21000,21500],
+    'sas':[8000, 8500, 9000, 9500, 10000, 10500, 11000, 11500, 12000, 12500,
+           13000, 13500, 14000, 14500, 15000, 15500, 16000, 16500, 17000, 17500,
+           18000, 18500, 19000, 19500, 20000],
+    'sto': [8202, 8357, 8857, 8974, 9150, 9450, 10025, 11181, 11274, 11458,
+            11940, 12240, 12300, 12515, 12539, 13285, 13340, 15022, 16370,
+            16689, 16720,  16799, 17910, 17982, 18778, 18890, 19674],}
+
+rad_max = {
+    'ade':[10700, 11200, 12300, 13300, 14800, 15300, 16300, 17300, 18300],
+    'adw':[10700, 11200, 12300, 13300, 14800, 15300, 16300, 17300, 18300],
+    'cly':[8500, 9000, 9500, 10000, 10500, 11000, 11500, 12000, 12500, 13000,
+           13469, 13929, 14500, 15040, 15500, 16000, 16500, 17000, 17500, 18000,
+           18500, 19000, 19500, 20040, 20500, 21000],
+    'han':[8335, 9040, 9985, 11275, 11600, 12415, 13260, 15080, 16360, 16615,
+           18050, 18865, 19680, 19755, 19990],
+    'inv':[8500, 9000, 9500, 10000, 10500, 11000, 11500, 12000, 12500,
+           13000,  13500, 14000, 14500, 15000, 15500, 16000, 16500, 17000,
+           17500, 18000, 18500, 19000,19500,20000,20500,21000,21500,22000],
+    'mcm':[10400, 11000, 11700, 12800, 14000, 14700, 15500, 17300, 18700],
+    'pgr':[8500, 9000, 9500, 10000, 10500, 11000, 11500, 12000, 12500,
+           13000,  13500, 14000, 14500, 15000, 15500, 16000, 16500, 17000,
+           17500, 18000, 18500, 19000,19500,20000,20500,21000,21500,22000],
+    'pyk':[8195, 8850, 9395, 10655, 11175, 11450, 11595, 12235, 12510, 13280,
+           13565, 13995, 15015, 16365, 16685, 17475, 18770, 18885, 20000,
+           11175],
+    'rkn':[8500, 9000, 9500, 10000, 10500, 11000, 11500, 12000, 12500,
+           13000,  13419, 14000, 14500, 15000, 15500, 16000, 16500, 17000,
+           17500, 18000, 18500, 19000,19500,20000,20500,21000,21500,22000],
+    'sas':[8500, 9000, 9500, 10000, 10500, 11000, 11500, 12000, 12500, 13000,
+           13500, 14000, 14500, 15000, 15500, 16000, 16500, 17000, 17500,
+           18000, 18500, 19000, 19500, 20000, 20500],
+    'sto': [8297, 8423, 8931, 8980, 9450, 9750, 10037, 11188, 11286, 11469,
+            12514, 12300, 12240, 12525, 12585, 13313, 13352, 15028, 16455,
+            16700, 16748, 16815, 17953, 17990, 18830, 18905, 19686],}
+
+# Allow use of both 3-letter code and numerical IDs
+id_to_code = {
+    5:'sas', 6:'pgr', 8:'sto', 9:'pyk', 10:'han', 20:'mcm', 64:'inv', 65:'rkn',
+    209:'ade', 208:'adw',}
+
+#-----------------------------------------------------------------------------
+class radFreqBands(object):
+    '''Contains the transmission frequency bands for a given radar
+
+    Parameters
+    ------------
+    rad : (str or int)
+       3-character radar code or numerical ID number
+
+    Attributes
+    ------------
+    rad_code : (str)
+        Radar 3-character code (lowercase only)
+    stid : (int)
+        Radar numerical ID
+    tbands : (list)
+        Transmision frequency band numbers
+    tmins : (list)
+        List of transmission frequency band lower boundaries (kHz)
+    tmaxs : (list)
+        List of transmission frequency band upper boundaries (kHz)
+
+    Methods
+    ---------
+    get_tband_max_min
+    get_mean_tband_freq
+    get_tfreq_band_num
+
+    written by AGB 25/07/16
+    '''
+    def __init__(self, rad=None):
+
+        # Assign the radar IDs
+        if id_to_code.has_key(rad):
+            self.rad_code = id_to_code[rad]
+            self.stid = rad
+        else:
+            self.rad_code = rad
+            self.stid = None
+
+            if rad is not None:
+                for stid in id_to_code.keys():
+                    if id_to_code[stid] is rad.lower():
+                        self.stid = stid
+                        break
+                    
+        # Assign the frequency bands
+        try:
+            self.tbands = rad_band_num[self.rad_code]
+            self.tmins = rad_min[self.rad_code]
+            self.tmaxs = rad_max[self.rad_code]
+        except:
+            self.tbands = list()
+            self.tmins = list()
+            self.tmaxs = list()
+
+    def __str__(self):
+        '''Object string representation
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        --------
+        ostr : (str)
+            Formatted output denoting the radar, the number of frequency bands,
+            and the frequency bands in MHz
+
+        Example
+        --------
+        In[1]: fb = davitpy.pydarn.radar.tdiff.rad_freqbands.radFreqBands(10)
+        In[2]: print fb
+        Radar transmission frequency bands:
+            Code: han       ID: 10
+            Number of frequency bands spanning 8.305-19.990 MHz: 15
+                Band Min_Freq-Max_Freq (MHz)
+                00 8.305-8.335
+                01 8.965-9.040
+                02 9.900-9.985
+                03 11.075-11.275
+                04 11.550-11.600
+                05 12.370-12.415
+                06 13.200-13.260
+                07 15.010-15.080
+                08 16.210-16.360
+                09 16.555-16.615
+                10 17.970-18.050
+                11 18.850-18.865
+                12 19.415-19.680
+                13 19.705-19.755
+                14 19.800-19.990
+        '''
+        ostr = "Radar transmission frequency bands:\n"
+        # Add radar name
+        ostr = "{:s}\tCode: {:s}\tID: {:d}\n".format(ostr, self.rad_code,
+                                                     self.stid)
+        # Add number of frequency bands
+        ostr = "{:s}\tNumber of frequency bands spanning ".format(ostr)
+        ostr = "{:s}{:.3f}-{:.3f} ".format(ostr, min(self.tmins) * 1.0e-3,
+                                           1.0e-3 * max(self.tmaxs))
+        ostr = "{:s}MHz: {:d}\n".format(ostr, len(self.tbands))
+        # Add the frequency bands
+        ostr = "{:s}\t\tBand Min_Freq-Max_Freq (MHz)\n".format(ostr)
+        for i,mm in enumerate(self.tmins):
+            ostr = "{:s}\t\t{:02d} {:.3f}-{:.3f}\n".format(ostr, self.tbands[i],
+                                                           mm * 1.0e-3, 1.0e-3 *
+                                                           self.tmaxs[i])
+        return ostr
+
+    #--------------------------------------------------------------------------
+    def get_tband_max_min(self, tfreq):
+        '''Return the maximum and minimum frequency for the band that the
+        supplied frequency falls into
+
+        Parameters
+        -------------
+        tfreq : (int)
+            Transmision frequency in kHz
+
+        Returns
+        -----------
+        min_freq : (int)
+            Minimum frequency in kHz, -1 if unavailable
+        max_freq : (int)
+            Maximum frequency in kHz, -1 if unavailable
+        '''
+        #------------------------------------------------
+        # Cycle through the transmission frequency bands
+        for i,t in enumerate(self.tmins):
+            if tfreq - t >= 0 and self.tmaxs[i] - tfreq >= 0:
+                return(t, self.tmaxs[i])
+        
+        logging.warn("Unknown transmission freq [{:d} kHz]".format(tfreq))
+        return(-1, -1)
+
+    def get_mean_tband_freq(self, tband):
+        ''' Return the maximum and minimum frequency for the band that the
+        supplied frequency falls into
+
+        Parameters
+        -------------
+        tband : (int)
+            Transmision band number
+
+        Returns
+        -----------
+        mean_freq : (int)
+            Mean frequency in kHz, -1 if unavailable
+        '''
+        mean_freq = -1
+            
+        #--------------------------------------------
+        # Ensure that band information is available
+        if len(self.tmins) > tband:
+            mean_freq = int((self.tmaxs[tband] + self.tmins[tband])
+                            / 2.0)
+        else:
+            estr = "unknown transmission freq band [{:}]".format(tband)
+            logging.warn(estr)
+
+        return mean_freq
+
+    def get_tfreq_band_num(self, tfreq):
+        ''' Retrieve the transmision frequency band number for a specified
+        frequency
+
+        Parameters
+        -----------
+        tfreq : (int)
+            Transmission frequency in kHz
+
+        Returns
+        ---------
+        tband : (int)
+            Transmission frequency band number, -1 if unavailable
+        '''
+        #--------------------------------------------
+        # Cycle through the different frequency bands
+        for i,t in enumerate(self.tmins):
+            if t <= tfreq and tfreq <= self.tmaxs[i]:
+                return(self.tbands[i])
+        
+        logging.warn("no band for frequency [{:} kHz]".format(tfreq))
+        return(-1)

--- a/davitpy/pydarn/radar/tdiff/rad_freqbands.py
+++ b/davitpy/pydarn/radar/tdiff/rad_freqbands.py
@@ -207,8 +207,8 @@ class radFreqBands(object):
         '''
         ostr = "Radar transmission frequency bands:\n"
         # Add radar name
-        ostr = "{:s}\tCode: {:s}\tID: {:d}\n".format(ostr, self.rad_code,
-                                                     self.stid)
+        ostr = "{:s}\tCode: {:}\tID: {:}\n".format(ostr, self.rad_code,
+                                                   self.stid)
         # Add number of frequency bands
         ostr = "{:s}\tNumber of frequency bands spanning ".format(ostr)
         ostr = "{:s}{:.3f}-{:.3f} ".format(ostr, min(self.tmins) * 1.0e-3,

--- a/davitpy/pydarn/radar/tdiff/simplex.py
+++ b/davitpy/pydarn/radar/tdiff/simplex.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#---------------------------------------
+# simplex.py, Angeline G. Burrell (AGB), UoL
+#
+# Comments: Simplex minimization functions
+#-----------------------------------------------------------------------------
+"""Simplex minimization functions
+
+Functions
+------------------------------------------------------------------------------
+rigerous_simplex  Implimentation of the Nelder-Mead simplex minimization
+------------------------------------------------------------------------------
+
+References
+------------------------------------------------------------------------------
+A.G. Burrell et al. (2016) submitted to Radio Science doi:xxx
+Nelder and Mead (1965) The Computer Journal, 7(4), 308-313
+------------------------------------------------------------------------------
+"""
+
+import scipy.optimize as sciopt
+import numpy as np
+
+#---------------------------------------------------------------------------
+def rigerous_simplex(x0, args, minfunc, tol, maxiter=500):
+    '''
+    An implimentation of the Nelder-Mead Simplex minimization function that
+    performs several tests to ensure that the returned minimum is a global
+    rather than local minima
+
+    Parameters
+    -----------
+    x0 : (float/int)
+        Initial guess for function minimum
+    args : (tuple)
+        Tuple containing the arguments needed to call the function
+    minfunc : (function)
+        Function to minimize
+    tol : (float)
+        Tolerance for the minimum.
+    maxiter : (int)
+        Maximum number of iterations to perform.  (default=500)
+
+    Returns
+    ---------
+    new_xmin : (float)
+        Function minimum
+    miter : (int)
+        Number of iterations needed to estimate xmin
+    res : (tuple)
+        Results from the successful simplex minimization run
+    '''
+    # Initialize test variables
+    mi = 0
+    local_min = None
+    func_min = dict()
+    imin = 2
+    xmin = x0
+
+    #--------------------------------------------------------------------------
+    # Perform the minimization using the Nelder-Mead Simplex method
+    while mi < maxiter:
+        # The Nelder-Mead method is not robust, and so will often return
+        # a local minimum.  Starting with this minimum, though, will cause
+        # the routine to consider a larger portion of data and eventually land
+        # in the a grand minimum
+        res = sciopt.minimize(minfunc, np.array(xmin), args=args,
+                              method='Nelder-Mead', tol=tol,
+                              options={"maxiter":maxiter, "disp":True})
+        new_xmin = float(res['x'])
+        mi += res['nit']
+
+        if local_min is not None:
+            xmin = local_min
+
+        if abs(new_xmin - xmin) < tol:
+            if local_min is None and not func_min.has_key(res['fun']):
+                # This function likely has a lot of local minima.  Give xmin
+                # a kick in both directions and see if it is stable
+                local_min = xmin
+                imin += 0.5
+                tinc = 0.001 * imin
+                tsign = np.sign(xmin - x0)
+                new_xmin += tinc * tsign
+                func_min[res['fun']] = [1, tinc, tsign, xmin, res]
+            elif func_min.has_key(res['fun']) and func_min[res['fun']][0] == 1:
+                # Now try the second direction
+                fmin = func_min[res['fun']]
+                new_xmin = fmin[3] - fmin[2] * fmin[1]
+                func_min[res['fun']][0] += 1
+            else:
+                break
+        elif local_min is not None:
+            local_min = None
+
+        xmin = new_xmin
+
+    if mi > maxiter:
+        new_xmin = np.nan
+    else:
+        # Test to ensure that the minimum we settled is closest to the global
+        # minimum
+        fmin = min(func_min.keys())
+        if res['fun'] > fmin:
+            new_xmin = func_min[fmin][3]
+            res = func_min[fmin][4]
+
+    return new_xmin, mi, res

--- a/davitpy/pydarn/radar/tdiff/test_tdiff.py
+++ b/davitpy/pydarn/radar/tdiff/test_tdiff.py
@@ -9,7 +9,9 @@
 
 Functions
 -------------------------------------------------------------------------------
-
+test_simplex               Test the rigorous_simplex routine in simplex.py
+han_heater_field_line_lat  Trace basic field-lines for HAN-heater combos
+test_calc_tdiff            Test calc_tdiff for an example from the RS article
 -------------------------------------------------------------------------------
 
 References

--- a/davitpy/pydarn/radar/tdiff/test_tdiff.py
+++ b/davitpy/pydarn/radar/tdiff/test_tdiff.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#---------------------------------------
+# test_tdiff.py, Angeline G. Burrell (AGB), UoL
+#
+# Comments: Functions to test the performance of the tdiff routines
+#-----------------------------------------------------------------------------
+"""This module contains routines to test the tdiff routines
+
+Functions
+-------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+
+References
+------------------------------------------------------------------------------
+A.G. Burrell et al. (2016) submitted to Radio Science doi:xxx
+------------------------------------------------------------------------------
+"""
+import numpy as np
+import logging
+
+def test_simplex(plot_handle=None):
+    ''' Find the minimum of a sine function closest to a specified x-value
+
+    Parameters
+    ----------
+    plot_handle : (figure handle or NoneType)
+        Figure handle to plot output on or None if no plot is desired
+        (default=None)
+
+    Returns
+    --------
+    min0 : (float)
+        Minimum closest to zero degrees (-90 degrees)
+    min1 : (float)
+        Minimum closest to 180 degrees (360 degrees)
+    min2 : (float)
+        Minimum closest to -271 degrees (-360 degrees)
+
+    Example
+    --------
+    In [1]: import test_tdiff
+    In [2]: min0, min1, min2 = test_tdiff.test_simplex()
+    Optimization terminated successfully.
+         Current function value: -1.000000
+         Iterations: 26
+         Function evaluations: 52
+    Optimization terminated successfully.
+         Current function value: -1.000000
+         Iterations: 11
+         Function evaluations: 22
+    Optimization terminated successfully.
+         Current function value: -1.000000
+         Iterations: 11
+         Function evaluations: 22
+    Optimization terminated successfully.
+         Current function value: -1.000000
+         Iterations: 17
+         Function evaluations: 34
+    Optimization terminated successfully.
+         Current function value: -1.000000
+         Iterations: 13
+         Function evaluations: 26
+    Optimization terminated successfully.
+         Current function value: -1.000000
+         Iterations: 13
+         Function evaluations: 26
+    Optimization terminated successfully.
+         Current function value: -1.000000
+         Iterations: 19
+         Function evaluations: 38
+    Optimization terminated successfully.
+         Current function value: -1.000000
+         Iterations: 13
+         Function evaluations: 26
+    Optimization terminated successfully.
+         Current function value: -1.000000
+         Iterations: 13
+         Function evaluations: 26
+    In [3]: print min0, min1, min2
+    -1.5708125 4.71238898038 -7.85400933085
+    '''
+    from simplex import rigerous_simplex
+    
+    def sin_func(angle_rad):
+        return np.sin(angle_rad)
+
+    x = np.arange(-3.0*np.pi, 3.0*np.pi, .1)
+    x0 = 0.0
+    x1 = np.pi
+    x2 = np.radians(-271.0)
+
+    tol = 1.0e-4
+    args = ()
+
+    min0, mi, res = rigerous_simplex(x0, args, sin_func, tol)
+    min1, mi, res = rigerous_simplex(x1, args, sin_func, tol)
+    min2, mi, res = rigerous_simplex(x2, args, sin_func, tol)
+
+    if plot_handle is not None:
+        import matplotlib as mpl
+        # Initialize the figure
+        ax = plot_handle.add_subplot(1,1,1)
+
+        # Plot the data
+        y = sin_func(x)
+        ax.plot(np.degrees(x), y, "k-")
+        ax.plot([np.degrees(x0), np.degrees(x0)], [-1,1], "k--")
+        ax.plot([np.degrees(x1), np.degrees(x1)], [-1,1], "k--")
+        ax.plot([np.degrees(x2), np.degrees(x2)], [-1,1], "k--")
+        ax.plot([np.degrees(min0), np.degrees(min0)], [-1,1], "k-.")
+        ax.plot([np.degrees(min1), np.degrees(min1)], [-1,1], "k-.")
+        ax.plot([np.degrees(min2), np.degrees(min2)], [-1,1], "k-.")
+
+        # Add labels
+        ax.set_xlabel("x (degrees)")
+        ax.set_ylabel("sin(x)")
+        ax.text(np.degrees(x0) + 10,0,"x$_0$")
+        ax.text(np.degrees(x1) + 10,0,"x$_1$")
+        ax.text(np.degrees(x2) + 10,0,"x$_2$")
+        ax.text(np.degrees(min0) + 10,0,"min$_0$")
+        ax.text(np.degrees(min1) + 10,0,"min$_1$")
+        ax.text(np.degrees(min2) + 10,0,"min$_2$")
+
+        # Make the x-axis sensible
+        ax.xaxis.set_major_locator(mpl.ticker.MultipleLocator(90))
+        ax.set_xlim(-540, 540)
+
+    return min0, min1, min2
+
+def han_heater_field_line_lat(alt, heater="Tromso"):
+    '''Calculate the latitude for a field line irregularity produced by heater
+    and observed by Hankasalmi
+
+    Parameters
+    --------------
+    alt : (float or np.ndarray)
+        Altitude in kilometers
+    heater : (str)
+        Heater name (SPEAR or Tromso, case insensitive) (default="Tromso")
+
+    Returns
+    lat : (float or np.ndarray)
+        Latitude in degrees
+    '''
+
+    heater_lat = 78.15 if heater.lower() == "spear" else 69.90
+    heater_ang = 7.7 if heater.lower() == "spear" else 12.0
+    line_lat = heater_lat - (alt * np.tan(np.radians(heater_ang)) / 111.0)
+    
+    return line_lat
+
+def test_calc_tdiff(file_type="fitacf", password=True, tdiff_plot=None):
+    '''Test calc_tdiff
+
+    Parameters
+    -----------
+    file_type : (str)
+        Type of file to load (default="fitacf")
+    password : (str, bool, NoneType)
+        Password to access SuperDARN database (default=True)
+    tdiff_plot : (matplotlib.figure.Figure or NoneType)
+        figure handle for output or None to not produce a plot (default=None)
+
+    Returns
+    -----------
+    test_tdiff : (float)
+        tdiff for 11.075-11.275 MHz at han on 13 Oct 2006
+    trange : (np.ndarray)
+        Numpy array of tdiff values spanning 6 periods centred about test_tdiff
+    ldist : (np.ndarray)
+        Numpy array of latitude distribution values for each trange value.
+        Can be used with trange to examine the function that was minimized to
+        find test_tdiff
+
+    Example
+    ----------
+    In[1]: import davitpy.radar.tdiff as dtdiff
+    In[5]: tt, trange, ldist = dtdiff.test_tdiff.test_calc_tdiff()
+    --- shows simplex output ---
+    In[6]: print tt[0]
+    0.15493524451202445
+    In[7]: print tt[-1]
+    final_simplex: (array([[ 0.15493524],
+       [ 0.15499577]]), array([ 0.69607672,  0.69607734]))
+           fun: 0.69607671732767618
+       message: 'Optimization terminated successfully.'
+          nfev: 16
+           nit: 8
+        status: 0
+       success: True
+             x: array([ 0.15493524])
+    '''
+    import datetime as dt
+    import davitpy.pydarn.radar as pyrad
+    import davitpy.pydarn.sdio as sdio
+    import davitpy.pydarn.proc.fov as fov
+    import davitpy.pydarn.radar.tdiff.bscatter_distribution as bs_dist
+
+    # Set the radar beam selection criteria
+    rad = 'han'
+    radcp = -6401
+    stime = dt.datetime(2006, 10, 13, 15)
+    etime = dt.datetime(2006, 10, 13, 15, 30)
+
+    # Load the data
+    try:
+        rad_ptr = sdio.radDataRead.radDataOpen(stime, rad, eTime=etime,
+                                               fileType=file_type,
+                                               password=password, cp=radcp)
+    except:
+        print "Unable to load tdiff test data:\nRadar: {:s}".format(rad)
+        print "Program: {:d}\nTime: {:} to {:}".format(radcp, stime, etime)
+        return None
+
+    hard = pyrad.site(code=rad, dt=stime)
+    rad_bands = pyrad.tdiff.rad_freqbands.radFreqBands(rad)
+    
+    # Set the beam selection criteria
+    tb = 3
+    bnum = 5
+    pmin = 10.0
+    rmin = 10
+    rmax = 25
+    tmins = [dt.datetime(2006, 10, 13, 15, 4), dt.datetime(2006, 10, 13, 15, 8),
+             dt.datetime(2006, 10, 13, 15, 12)]
+    tmaxs = [dt.datetime(2006, 10, 13, 15, 6),dt.datetime(2006, 10, 13, 15, 10),
+             dt.datetime(2006, 10, 13, 15, 14)]
+    sattr = ["slist", "time", "tfreq", "p_l", "phi0", "phi0e", "bmnum", "dist"]
+    
+    bm = rad_ptr.readRec()
+    beams = list()
+    while bm is not None:
+        tband = rad_bands.get_tfreq_band_num(bm.prm.tfreq)
+        if bm.bmnum == bnum and tband == tb:
+            if hasattr(bm, "fit"):
+                # Add attribute to beam
+                bm.fit.dist = fov.update_backscatter.calc_distance(bm)
+                beams.append(bm)
+        bm = rad_ptr.readRec()
+
+    sdata = pyrad.tdiff.calc_tdiff.select_bscatter(beams, sattr, radcp, tb,
+                                                   bnum, min_power=pmin,
+                                                   min_rg=rmin, max_rg=rmax,
+                                                   stimes=tmins, etimes=tmaxs)
+
+    # Set the reference location
+    tperiod = 1000.0 / rad_bands.get_mean_tband_freq(tb)
+    ref_alt = 230.0
+    ref_lat = han_heater_field_line_lat(ref_alt, heater="tromso")
+    ref_err = max(abs(han_heater_field_line_lat(np.array([ref_alt - 10.0,
+                                                          ref_alt + 10.0]),
+                                                heater="tromso") - ref_lat))
+    asep = np.sqrt(np.dot(hard.interfer, hard.interfer))
+    phi_sign = 1.0 if hard.interfer[1] > 0.0 else -1.0
+    ecor = phi_sign * hard.phidiff * np.arcsin(hard.interfer[2] / asep)
+    ttol = 1.0e-4
+    fovflg = [1 for i in sdata["phi0"]]
+    cos_phi = [np.cos(np.radians(hard.beamToAzim(b) - hard.boresite))
+               for b in sdata['bmnum']]
+    lat_args = (hard, asep, phi_sign, ecor, sdata["phi0"], sdata["phi0e"],
+                fovflg, cos_phi, sdata["tfreq"], sdata['bmnum'], sdata['dist']) 
+
+    # Estimate tdiff
+    tout = pyrad.tdiff.calc_tdiff.calc_tdiff(hard.tdiff, ref_lat, ref_err,
+                                             lat_args, bs_dist.lat_distribution,
+                                             0.01, tdiff_tol=ttol,
+                                             tperiod=tperiod)
+
+    # Calculate the latitude distribution as a function of tdiff
+    trange = np.arange(tout[0] - 3.0 * tperiod, tout[0] + 3.0 * tperiod, ttol)
+    ldist = np.array([bs_dist.lat_distribution(t, *((ref_lat,) + lat_args))
+                      for t in trange])
+
+    # If desired, create the figure showing the data selection results,
+    # tdiff functional variations, and difference in the location distributions
+    # using the initial and final tdiffs
+    if tdiff_plot is not None:
+        import matplotlib as mpl
+        import matplotlib.pyplot as plt
+        from davitpy.utils import calcDistPnt
+        try:
+            sax = tdiff_plot.add_subplot(3,1,1)
+            hax = tdiff_plot.add_subplot(2,2,4)
+            tax = tdiff_plot.add_subplot(2,2,3)
+        except:
+            print "Unable to add subplots to figure"
+            return tout[0], trange, ldist
+
+        # Add the title
+        stitle = "{:s} Beam {:d} on {:}\n".format(rad, bnum, stime.date())
+        stitle = "{:s}{:.3f}-{:.3f} MHz with {:d}".format(stitle, \
+                    rad_bands.tmins[tb] / 1000.0, rad_bands.tmaxs[tb] / 1000.0,
+                                                          len(sdata['phi0']))
+        stitle = "{:s} heater backscatter observations".format(stitle)
+        tdiff_plot.suptitle(stitle)
+
+        # Extract all of the read in data for the selected beam
+        sax_time = list()
+        sax_range = list()
+        sax_p = list()
+
+        for bm in beams:
+            for i,ss in enumerate(bm.fit.slist):
+                sax_time.append(bm.time)
+                sax_range.append(ss)
+                sax_p.append(bm.fit.p_l[i])
+
+        # Identify selected data over RTI using power as intensity
+        sax.scatter(sax_time, sax_range, c=sax_p, vmin=0, vmax=40,
+                    cmap=mpl.cm.get_cmap("Spectral_r"), marker="|",
+                    linewidth=14, s=45, zorder=2)
+        sax.plot(sdata["time"], sdata["slist"], "k.", zorder=3)
+
+        for i,ss in enumerate(tmins):
+            p = mpl.patches.Rectangle((mpl.dates.date2num(ss), rmin),
+                                      (tmaxs[i]-ss).total_seconds()/86400.,
+                                      rmax-rmin, color="0.6", zorder=1)
+            sax.add_patch(p)
+        
+        sax.xaxis.set_major_formatter(mpl.dates.DateFormatter("%H:%M"))
+        sax.xaxis.set_major_locator(mpl.dates.MinuteLocator(interval=5))
+        sax.yaxis.set_major_locator(mpl.ticker.MultipleLocator(5))
+        sax.set_xlim(stime, etime)
+        sax.set_ylim(rmin - 1, rmax + 1)
+        sax.set_xlabel("Universal Time (HH:MM)")
+        sax.set_ylabel("Range Gate")
+        sax.set_axis_bgcolor("0.9")
+
+        cb = fov.test_update_backscatter.add_colorbar(tdiff_plot, \
+                sax.collections[0], 0, 40, 5, name="Power", units="dB",
+                                                      loc=[.91, .67, .01, .22])
+
+        # Add the tdiff-lat dist function 
+        tax.plot(trange, ldist, "b-", linewidth=2)
+        ymin, ymax = tax.get_ylim()
+        tax.plot([hard.tdiff, hard.tdiff], [ymin, ymax], "k--", linewidth=2,
+                 label="Initial $\delta t_c$")
+        tax.plot([tout[0], tout[0]], [ymin, ymax], "k-", linewidth=2,
+                 label="Estimated $\delta t_c$")
+        tax.plot([tout[0]+tperiod, tout[0]+tperiod], [ymin, ymax], "-", c="0.6",
+                 linewidth=2, label="Estimated $\delta t_c$ $\pm$ T")
+        tax.plot([tout[0]-tperiod, tout[0]-tperiod], [ymin, ymax], "-", c="0.6",
+                 linewidth=2)
+        tax.plot([tout[0]+2.0*tperiod, tout[0]+2.0*tperiod], [ymin, ymax], "-",
+                 c="0.8", linewidth=2, label="Estimated $\delta t_c$ $\pm$ 2T")
+        tax.plot([tout[0]-2.0*tperiod, tout[0]-2.0*tperiod], [ymin, ymax], "-",
+                 c="0.8", linewidth=2)
+
+        tax.set_xlim(tout[0]-2.5*tperiod, tout[0]+2.5*tperiod)
+        tax.set_ylim(ymin, ymax)
+        tax.set_xlabel("$\delta t_c$ ($\mu s$)")
+        tax.set_ylabel("g($\delta t_c$) ($^\circ$)")
+        tax.legend(ncol=2, fontsize="xx-small", bbox_to_anchor=(1.1,1.33))
+
+        # Add the latitude histogram
+        elv = np.array(fov.calc_elevation.calc_elv_list(sdata['phi0'],
+                                                        sdata['phi0e'], fovflg,
+                                                        cos_phi, sdata['tfreq'],
+                                                        asep,ecor, phi_sign,
+                                                        hard.tdiff))
+        loc = calcDistPnt(hard.geolat, hard.geolon, hard.alt,
+                          az=hard.beamToAzim(np.array(sdata['bmnum'])),
+                          el=np.degrees(elv), dist=np.array(sdata['dist']))
+
+        hax.hist(loc['distLat'], 8, color="0.6",
+                 label="{:.3f}".format(hard.tdiff))
+       
+        elv = np.array(fov.calc_elevation.calc_elv_list(sdata['phi0'],
+                                                        sdata['phi0e'], fovflg,
+                                                        cos_phi, sdata['tfreq'],
+                                                        asep, ecor, phi_sign,
+                                                        tout[0]))
+        loc = calcDistPnt(hard.geolat, hard.geolon, hard.alt,
+                          az=hard.beamToAzim(np.array(sdata['bmnum'])),
+                          el=np.degrees(elv), dist=np.array(sdata['dist']))
+
+        hax.hist(loc['distLat'], 8, color="c", alpha=.5,
+                 label="{:.3f}".format(tout[0]))
+
+        # Set the main axis labels and limits
+        xmin, xmax = hax.get_xlim()
+        hax.set_ylim(0, 15)
+        hax.set_ylabel("Counts")
+        hax.yaxis.set_label_coords(-.08, .5)
+        hax.yaxis.set_major_locator(mpl.ticker.MultipleLocator(3))
+        hax.set_xlabel("Latitude ($^\circ$)")
+        hax.xaxis.set_major_locator(mpl.ticker.MultipleLocator(1))
+        hax.legend(ncol=2, fontsize="xx-small", title="$\delta t_c$ ($\mu s$)",
+                   bbox_to_anchor=(.85,1.33))
+       
+        # Add the reference locations to a twin of the histogram plot
+        hax2 = hax.twinx()
+        line_alt = np.arange(0.0, 315.0, 15.0)
+        line_lat = han_heater_field_line_lat(line_alt, heater="tromso")
+        hax2.plot(line_lat, line_alt, "k-", linewidth=4)
+        hax2.plot([xmin, xmax], [ref_alt, ref_alt], "k:")
+        hax2.plot([ref_lat, ref_lat], [0, 300], "k--", linewidth=2)
+        
+        hax.set_xlim(xmin, xmax)
+        hax2.set_ylabel("Altitude (km)")
+
+    return tout[0], trange, ldist

--- a/davitpy/pydarn/radar/tdiff/test_tdiff.py
+++ b/davitpy/pydarn/radar/tdiff/test_tdiff.py
@@ -181,18 +181,8 @@ def test_calc_tdiff(file_type="fitacf", password=True, tdiff_plot=None):
     In[1]: import davitpy.radar.tdiff as dtdiff
     In[5]: tt, trange, ldist = dtdiff.test_tdiff.test_calc_tdiff()
     --- shows simplex output ---
-    In[6]: print tt[0]
+    In[6]: print tt
     0.15493524451202445
-    In[7]: print tt[-1]
-    final_simplex: (array([[ 0.15493524],
-       [ 0.15499577]]), array([ 0.69607672,  0.69607734]))
-           fun: 0.69607671732767618
-       message: 'Optimization terminated successfully.'
-          nfev: 16
-           nit: 8
-        status: 0
-       success: True
-             x: array([ 0.15493524])
     '''
     import datetime as dt
     import davitpy.pydarn.radar as pyrad
@@ -214,7 +204,7 @@ def test_calc_tdiff(file_type="fitacf", password=True, tdiff_plot=None):
     except:
         print "Unable to load tdiff test data:\nRadar: {:s}".format(rad)
         print "Program: {:d}\nTime: {:} to {:}".format(radcp, stime, etime)
-        return None
+        return None, None, None
 
     hard = pyrad.site(code=rad, dt=stime)
     rad_bands = pyrad.tdiff.rad_freqbands.radFreqBands(rad)


### PR DESCRIPTION
Addition to davitpy that allows frequency dependent tdiff estimates to be made for any radar.  The article explaining the method will be resubmitted on Friday.  If you'd like a copy of the manuscript to see what's going on in more detail I'm happy to send it to you.

Changes and additions have been made in two areas.  The major changes are:

pydarn/proc/fov -> Added a new routine to calculate elevation angles
pydarn/radar -> Added tdiff directory and routines

Testing for fov and radar/tdiff are outlined in following comments.