### PR TITLE
overlayFov groundscatter model bugfix

### DIFF
--- a/davitpy/pydarn/plotting/mapOverlay.py
+++ b/davitpy/pydarn/plotting/mapOverlay.py
@@ -203,9 +203,11 @@ def overlayFov(mapObj, codes=None, ids=None, names=None, dateTime=None,
     model : Optional[str]
         'IS for ionopsheric scatter projection model (default), 'GS' for
         ground scatter projection model, None if you are really
-        confident in your elevation or altitude values
+        confident in your elevation or altitude values.  fov object will over
+        write this choice.
     fov_dir : Optional[str] 
-        Field of view direction ('front' or 'back'). Default='front'
+        Field of view direction ('front' or 'back'). Value in fov object will
+        overwrite this choice.  Default='front'
     zorder : Optional[int]
         The overlay order number
     lineColor : Optional[str]
@@ -290,7 +292,7 @@ def overlayFov(mapObj, codes=None, ids=None, names=None, dateTime=None,
     # iterates through radars to be plotted
     for ir in xrange(nradars):
         # Get field of view coordinates
-        if(fovObj is None):
+        if fovObj is None:
             rad = network_obj.getRadarBy(rad_input['vals'][ir],
                                          rad_input['meth'])
             if not rad:
@@ -312,6 +314,8 @@ def overlayFov(mapObj, codes=None, ids=None, names=None, dateTime=None,
             rad_fov = fovObj
             egate = len(fovObj.gates)
             ebeam = len(fovObj.beams)
+            model = fovObj.model
+            fov_dir = fovObj.fov_dir
 
         if rangeLimits is not None:
             sgate = rangeLimits[0]

--- a/davitpy/pydarn/radar/radFov.py
+++ b/davitpy/pydarn/radar/radFov.py
@@ -361,9 +361,9 @@ class fov(object):
                         slant_range_center[ib, ig] = \
                             gsMapSlantRange(srang_center[ig], altitude=None,
                                             elevation=None)
-                        slant_range_full[ib, ig] = gsMapSlantRange(srang_edge[ig],
-                                                                   altitude=None,
-                                                                   elevation=None)
+                        slant_range_full[ib, ig] = \
+                            gsMapSlantRange(srang_edge[ig], altitude=None,
+                                            elevation=None)
                         srang_center[ig] = slant_range_center[ib, ig]
                         srang_edge[ig] = slant_range_full[ib, ig]
 
@@ -406,25 +406,23 @@ class fov(object):
         self.beams = beams[:-1]
         self.gates = gates[:-1]
         self.coords = coords
+        self.fov_dir = fov_dir
+        self.model = model
 
     # *************************************************************
     def __str__(self):
-        outstring = 'latCenter: {} \
-                     \nlonCenter: {} \
-                     \nlatFull: {} \
-                     \nlonFull: {} \
-                     \nslantRCenter: {} \
-                     \nslantRFull: {} \
-                     \nbeams: {} \
-                     \ngates: {} \
-                     \ncoords: {}'.format(np.shape(self.latCenter),
-                                          np.shape(self.lonCenter),
-                                          np.shape(self.latFull),
-                                          np.shape(self.lonFull),
-                                          np.shape(self.slantRCenter),
-                                          np.shape(self.slantRFull),
-                                          np.shape(self.beams),
-                                          np.shape(self.gates), self.coords)
+        outstring = 'latCenter: {}\nlonCenter: {}\nlatFull: {}\nlonFull: {} \
+                     \nslantRCenter: {}\nslantRFull: {}\nbeams: {} \
+                     \ngates: {} \ncoords: {} \nfield of view: {}\
+                     \nmodel: {}'.format(np.shape(self.latCenter),
+                                         np.shape(self.lonCenter),
+                                         np.shape(self.latFull),
+                                         np.shape(self.lonFull),
+                                         np.shape(self.slantRCenter),
+                                         np.shape(self.slantRFull),
+                                         np.shape(self.beams),
+                                         np.shape(self.gates), self.coords,
+                                         self.fov_dir, self.model)
         return outstring
 
 
@@ -547,13 +545,13 @@ def calcFieldPnt(tGeoLat, tGeoLon, tAlt, boreSight, boreOffset, slantRange,
         # Using no models simply means tracing based on trustworthy elevation
         # or altitude
         if not altitude:
-            altitude = np.sqrt(Re ** 2 + slantRange ** 2 + 2. * slantRange * Re *
+            altitude = np.sqrt(Re**2 + slantRange**2 + 2. * slantRange * Re *
                                np.sin(np.radians(elevation))) - Re
         if not elevation:
             if(slantRange < altitude):
                 altitude = slantRange - 10
-            elevation = np.degrees(asin(((Re + altitude) ** 2 - (Re + tAlt) ** 2 -
-                                         slantRange ** 2) /
+            elevation = np.degrees(asin(((Re + altitude)**2 - (Re + tAlt)**2 -
+                                         slantRange**2) /
                                         (2. * (Re + tAlt) * slantRange)))
         # The tracing is done by calcDistPnt
         dict = geoPack.calcDistPnt(tGeoLat, tGeoLon, tAlt, dist=slantRange,


### PR DESCRIPTION
Fixed bug that caused fields-of-view to not close when the groundscatter model is used.

To test: 

import datetime as dt
import davitpy
import matplotlib.pyplot as plt
plt.ion()
f = plt.figure()
ax = f.add_subplot(1,1,1)
import mpl_toolkits.basemap as basemap
rad = 'han'
stime = dt.datetime(2006, 10, 1)
hard = davitpy.pydarn.radar.site(code=rad, dt=stime)
m = davitpy.utils.mapObj(ax=ax, projection="stere", lon_0=hard.geolon, lat_0=hard.geolat, llcrnrlon=0, llcrnrlat=25, urcrnrlat=70, urcrnrlon=135, resolution="l")
m.drawcoastlines(linewidth=0.5, color="0.6")
fov_test = davitpy.pydarn.radar.radFov.fov(site=hard, ngates=75, altitude=350, coords="geo", model="GS", fov_dir="front")
davitpy.pydarn.plotting.overlayFov(m, rad, fovObj=fov_test)

fov_test = davitpy.pydarn.radar.radFov.fov(site=hard, ngates=75, altitude=350, coords="geo", model="IS", fov_dir="back")
davitpy.pydarn.plotting.overlayFov(m, rad, fovObj=fov_test, fovColor="b")

![gs_fov](https://cloud.githubusercontent.com/assets/7045886/17740425/761fde40-6490-11e6-820d-d60f6e322bcb.png)

print fov_test

latCenter: (16, 75)
lonCenter: (16, 75)
latFull: (17, 76)
lonFull: (17, 76)                      
slantRCenter: (16, 75)
slantRFull: (17, 76)
beams: (16,)                      
gates: (75,) 
coords: geo 
field of view: back                     
model: IS


