### PR TITLE
Fixed typo resulting in incorrect B component

### DIFF
--- a/davitpy/gme/plotting/gmeplot.py
+++ b/davitpy/gme/plotting/gmeplot.py
@@ -243,7 +243,7 @@ def plotOmni(omniList,parameter=None,sTime=None,eTime=None,ymin=None,
       if(parameter[0] == 'al'): ylabel = 'AL [nT]'
       if(parameter[0] == 'au'): ylabel = 'AU [nT]'
       if(parameter[0] == 'bx'): ylabel = 'Bx [nT]'
-      if(parameter[0] == 'bze'): ylabel = 'By GSE [nT]'
+      if(parameter[0] == 'bye'): ylabel = 'By GSE [nT]'
       if(parameter[0] == 'bze'): ylabel = 'Bz GSE [nT]'
       if(parameter[0] == 'bym'): ylabel = 'By GSM [nT]'
       if(parameter[0] == 'bzm'): ylabel = 'Bz GSM [nT]'


### PR DESCRIPTION
As identified in https://github.com/vtsuperdarn/davitpy/issues/270 there was a typo in `gmeplot.py` that prevented the `bye` component from being labeled, but also caused the `bze` component to be mislabeled as "By GSE [nT]".

This pull request fixes this issue.

@Shirling-VT can you please provide the code to test this pull request?