### PR TITLE
Use full release of basemap

### DIFF
--- a/install/debian_dependencies.sh
+++ b/install/debian_dependencies.sh
@@ -56,7 +56,7 @@ pip install -U cryptography
 
 #install basemap
 cd /tmp
-git clone https://github.com/matplotlib/basemap.git
+git clone --branch v1.0.7rel https://github.com/matplotlib/basemap.git
 cd basemap/geos-3.3.3
 export GEOS_DIR=/usr/local
 ./configure --prefix=$GEOS_DIR

--- a/install/python_install_mac_brew.sh
+++ b/install/python_install_mac_brew.sh
@@ -35,6 +35,6 @@ pip install --upgrade pandas
 
 dir=$(pwd)
 cd /tmp
-git clone https://github.com/matplotlib/basemap.git
+git clone --branch v1.0.7rel https://github.com/matplotlib/basemap.git
 python2.7 setup.py install
 

--- a/install/python_install_mac_port.sh
+++ b/install/python_install_mac_port.sh
@@ -30,6 +30,6 @@ pip install --upgrade pandas
 
 dir=$(pwd)
 cd /tmp
-git clone https://github.com/matplotlib/basemap.git
+git clone --branch v1.0.7rel https://github.com/matplotlib/basemap.git
 cd basemap
 python2.7 setup.py install

--- a/install/suse_dependencies.sh
+++ b/install/suse_dependencies.sh
@@ -71,7 +71,7 @@ dir=$(pwd)
 
 #Now install basemap!
 cd /tmp
-git clone https://github.com/matplotlib/basemap.git
+git clone --branch v1.0.7rel https://github.com/matplotlib/basemap.git
 cd basemap/geos-3.3.3
 export GEOS_DIR=/usr/local
 ./configure --prefix=$GEOS_DIR


### PR DESCRIPTION
This fixes issue #294.

We have been installing a rolling release of basemap instead of a release. This hotfix fixes that.

When this pull request is finished, it will have to be pulled into develop also.