### PR TITLE
Removed unnecessary plotCoords variable that caused bug.

### DIFF
--- a/davitpy/pydarn/plotting/plotMapGrd.py
+++ b/davitpy/pydarn/plotting/plotMapGrd.py
@@ -34,8 +34,6 @@ class MapConv(object):
     maxVelScale : Optional[float]
         maximum velocity to be used for plotting, min is zero so scale is
         [0,1000]
-    plotCoords : Optional[str]
-        coordinates of the plot, only use either 'mag' or 'mlt'
 
     Attributes
     ----------
@@ -52,7 +50,7 @@ class MapConv(object):
         the axis handle used
     mObj : utils.plotUtils.mapObj
         the map object you want data to be overlayed on.
- 
+
 
     Methods
     --------

--- a/davitpy/pydarn/plotting/plotMapGrd.py
+++ b/davitpy/pydarn/plotting/plotMapGrd.py
@@ -122,12 +122,12 @@ class MapConv(object):
         # requested
         if hemi == "north":
             assert(mObj.boundarylats[0] > 0.), \
-                logging.error("Map object is using one hemisphere and data the"
-                              " other")
+                logging.error("Map and data objects must be from the same"
+                              " hemisphere")
         else:
             assert(mObj.boundarylats[0] < 0.), \
-                logging.error("Map object is using one hemisphere and data the"
-                              " other")
+                logging.error("Map and data objects must be from the same"
+                              " hemisphere")
 
         # check if hemi and coords keywords are correct
         assert(hemi == "north" or hemi == "south"), \

--- a/davitpy/pydarn/plotting/plotMapGrd.py
+++ b/davitpy/pydarn/plotting/plotMapGrd.py
@@ -103,7 +103,7 @@ class MapConv(object):
 
 
     def __init__(self, startTime, mObj, axisHandle, hemi='north',
-                 maxVelScale=1000., plotCoords='mag'):
+                 maxVelScale=1000.):
 
         import datetime
         from davitpy.pydarn.sdio import sdDataOpen
@@ -134,11 +134,8 @@ class MapConv(object):
         # check if hemi and coords keywords are correct
         assert(hemi == "north" or hemi == "south"), \
             logging.error("hemi should either be 'north' or 'south'")
-        assert(plotCoords == 'mag' or plotCoords == 'mlt'), \
-            logging.error("error, coords must be one of 'mag' or 'mlt'")
 
         self.hemi = hemi
-        self.plotCoords = plotCoords
 
         # Read the corresponding data record from both map and grid files.
         # This is the way I'm setting stuff up to avoid confusion of reading
@@ -215,18 +212,13 @@ class MapConv(object):
 
             # depending on whether we have 'mag' or 'mlt' coords,
             # calculate endLon
-            if self.plotCoords == 'mag':
-                endLon = mlonsPlot[nn] + numpy.degrees(delLon)
-            elif self.plotCoords == 'mlt':
-                endLon = (mlonsPlot[nn] + numpy.degrees(delLon)) / 15.
-            else:
-                logging.warning('Check the coords')
+            endLon = mlonsPlot[nn] + numpy.degrees(delLon)
 
             # get the start and end vecs
             xVecStrt, yVecStrt = self.mObj(mlonsPlot[nn], mlatsPlot[nn],
-                                           coords=self.plotCoords)
+                                           coords='mag')
             xVecEnd, yVecEnd = self.mObj(endLon, endLat,
-                                         coords=self.plotCoords)
+                                         coords='mag')
 
             # Plot the start point and then append the vector indicating magn.
             # and azimuth
@@ -612,14 +604,7 @@ class MapConv(object):
         else:
             logging.warning('LatShift is not zero, need to rewrite code for that, currently continuing assuming it is zero')
 
-        # mlt conversion stuff
-        if self.plotCoords == 'mlt':
-            epoch = timeUtils.datetimeToEpoch(self.mapData.sTime+datetime.timedelta(minutes=1))
-            mltDef = aacgm.mltFromEpoch(epoch,0.0) * 15.
-            lonShftFit += mltDef
-            gridArr[1,:] = numpy.mod( ( gridArr[1,:] + lonShftFit ) / 15., 24. )
-        else:
-            gridArr[1,:] = ( gridArr[1,:] + lonShftFit ) 
+        gridArr[1,:] = ( gridArr[1,:] + lonShftFit ) 
 
         latCntr = gridArr[0,:].reshape( ( 181, 60 ) )
         lonCntr = gridArr[1,:].reshape( ( 181, 60 ) )
@@ -651,7 +636,7 @@ class MapConv(object):
         ( latCntr, lonCntr, potCntr ) = self.calcCnvPots()
 
         #plot the contours
-        xCnt, yCnt = self.mObj( lonCntr, latCntr, coords=self.plotCoords )
+        xCnt, yCnt = self.mObj( lonCntr, latCntr, coords='mag')
         cntrPlt = self.mObj.contour( xCnt, yCnt, potCntr, 
             zorder = 2.,
             vmax=potCntr.max(), vmin=potCntr.min(), 
@@ -681,7 +666,7 @@ class MapConv(object):
 
         """
         xVecHMB, yVecHMB = self.mObj( self.mapData.model.boundarymlon, 
-            self.mapData.model.boundarymlat, coords = self.plotCoords )
+            self.mapData.model.boundarymlat, coords='mag' )
         grdPltHMB = self.mObj.plot( xVecHMB, yVecHMB, 
             linewidth = 2., linestyle = ':', color = hmbCol, zorder = 4. )
         grdPltHMB2 = self.mObj.plot( xVecHMB, yVecHMB, 
@@ -742,16 +727,10 @@ class MapConv(object):
             
             delLon = ( numpy.arctan2( numpy.sin(numpy.deg2rad( velAzm[nn] ) )*numpy.sin(vecLen)*numpy.cos(numpy.deg2rad( mlatsPlot[nn] ) ), numpy.cos(vecLen) - numpy.sin(numpy.deg2rad( mlatsPlot[nn] ) )*numpy.sin(numpy.deg2rad( endLat ) ) ) )
             
-            if self.plotCoords == 'mag':
-                endLon = mlonsPlot[nn] + numpy.degrees( delLon )
-            elif self.plotCoords == 'mlt':
-                endLon = ( mlonsPlot[nn] + numpy.degrees( delLon ) )/15.
-            else:
-                logging.warning('Check the coords.')
-                
-            
-            xVecStrt, yVecStrt = self.mObj(mlonsPlot[nn], mlatsPlot[nn], coords=self.plotCoords)
-            xVecEnd, yVecEnd = self.mObj(endLon, endLat, coords = self.plotCoords)
+            endLon = mlonsPlot[nn] + numpy.degrees( delLon )
+
+            xVecStrt, yVecStrt = self.mObj(mlonsPlot[nn], mlatsPlot[nn], coords='mag')
+            xVecEnd, yVecEnd = self.mObj(endLon, endLat, coords='mag')
 
             self.mapModelPltStrt = self.mObj.scatter( xVecStrt, yVecStrt, c=velMagn[nn], s=10.,
                 vmin=0, vmax=self.maxVelPlot, alpha=0.7, 
@@ -835,18 +814,10 @@ class MapConv(object):
                 numpy.cos(vecLen) - numpy.sin(numpy.deg2rad( mlatsPlot[nn] ) ) \
                 *numpy.sin(numpy.deg2rad( endLat ) ) ) )
             
-            if self.plotCoords == 'mag':
-                endLon = mlonsPlot[nn] + numpy.degrees( delLon )
-            elif self.plotCoords == 'mlt':
-                endLon = ( mlonsPlot[nn] + numpy.degrees( delLon ) )/15.
-            else:
-                logging.warning('Check the coords.')
-                
+            endLon = mlonsPlot[nn] + numpy.degrees( delLon )                
             
-            xVecStrt, yVecStrt = self.mObj(mlonsPlot[nn], mlatsPlot[nn], 
-                coords=self.plotCoords)
-            xVecEnd, yVecEnd = self.mObj(endLon, endLat, 
-                coords = self.plotCoords)
+            xVecStrt, yVecStrt = self.mObj(mlonsPlot[nn], mlatsPlot[nn], coords='mag')
+            xVecEnd, yVecEnd = self.mObj(endLon, endLat, coords='mag')
 
             self.mapFitPltStrt.append(self.mObj.scatter( xVecStrt, yVecStrt, 
                 c=velMagn[nn], s=10.,


### PR DESCRIPTION
As discussed to in #286, the plotCoords in `plotMapGrd.py` is actually unnecessary. Not only that but it actually causes a big problem in the convection map plotting when setting `plotCoords=mlt`. For example, running this code in `develop`:

    import datetime
    import matplotlib.pyplot as plt
    import davitpy.pydarn.plotting.plotMapGrd
    from davitpy.utils import *
    fig = plt.figure()
    ax = fig.add_subplot(111)
    sdate = datetime.datetime(2016, 3, 1, 9, 0)
    mObj = plotUtils.mapObj(boundinglat=50., datetime=sdate,
                            gridLabels=True, coords='mlt')
    mapDatObj = davitpy.pydarn.plotting.plotMapGrd.MapConv(sdate, mObj, ax,plotCoords='mlt')
    mapDatObj.overlayMapFitVel()
    mapDatObj.overlayCnvCntrs()
    mapDatObj.overlayHMB()
    plt.show()

will produce a groce (with a c) convection map plot:
![figure_1](https://cloud.githubusercontent.com/assets/4604819/22005610/9295946a-dc19-11e6-8d1c-4e5c940b88ae.png)

After squashing this bug with this pull request, you should be able to make beautiful plots that look like this:

![figure_2](https://cloud.githubusercontent.com/assets/4604819/22005613/a2e51958-dc19-11e6-837a-6c211a000503.png)

The `plotCoords` keyword has been removed since it doesn't actually do anything anymore, so when you run your code on this pull request make sure you don't use it.