### PR TITLE
Ubuntu 16.04 Raydarn Dependencies

### DIFF
--- a/install/debian_dependencies.sh
+++ b/install/debian_dependencies.sh
@@ -23,7 +23,9 @@ pip install -U pip
 #Now install the python package dependencies dependencies
 apt-get install -y python-imaging
 apt-get install -y python-gi-cairo  #needed in Ubuntu 16.04
+apt-get install -y python-tk        #needed in Ubuntu 16.04
 apt-get install -y mpich2
+apt-get install -y libmpich-dev     #needed in Ubuntu 16.04 for ray trace compile
 apt-get install -y gfortran
 apt-get install -y libhdf5-serial-dev
 apt-get install -y libfreetype6-dev 


### PR DESCRIPTION
Hi, Davitpy Devs!

@salsrag was having trouble running Raydarn on Ubuntu 16.04. I found that two dependencies are now required that were not installed. They are:

- libmpich-dev
- python-tk

This pull request adds those packages to debian_dependencies.sh.

Talk to you later,
Nathaniel