### PR TITLE
Removed problematic and unused rcParam

### DIFF
--- a/davitpy/rcsetup.py
+++ b/davitpy/rcsetup.py
@@ -230,7 +230,6 @@ defaultParams = {
                                  validate_string],
     'IGRF_DAVITPY_COEFF_FILE':	[model_coeffs_dir + 'igrf/igrf12coeffs.txt',
                                  validate_string],
-    'DAVITPY_PATH':             [path, validate_path_exists],
 
     # the verbosity setting for logging
     #'verbose.level': ['silent', validate_verbose],


### PR DESCRIPTION
Removed the rcParam ‘DAVITPY_PATH’, which has caused installation
issues and is not used anywhere at all (that I could find).

This pull request was made in response to issue #309 .