### PR TITLE
Use absolute paths instead of relative

### DIFF
--- a/davitpy/rcsetup.py
+++ b/davitpy/rcsetup.py
@@ -214,9 +214,10 @@ validate_verbose = ValidateInStrings(
     'verbose',
     ['silent', 'helpful', 'debug', 'debug-annoying'])
 
+# Installation path of davitpy (based on location of this file)
+path = os.path.abspath(os.path.split(os.path.dirname(__file__))[0])
 
 # determine install location of model coefficients
-path = os.path.split(os.path.dirname(__file__))[0]
 model_coeffs_dir = os.path.join(path, 'tables/')
 
 if not os.path.exists(model_coeffs_dir):


### PR DESCRIPTION
This pull request fixes the bug reported in #309.

The problem was caused because relative paths were used instead of absolute paths. See https://github.com/vtsuperdarn/davitpy/issues/309#issuecomment-336820639 for more details.

Testing is:
1) Without this pull request, try importing davitpy from within the davitpy source directory (if you have the source at /home/user/davitpy, then cd there and try to import). This will fail.
2) With this pull request, try 1). It will work.

Thanks to @arfogg for reporting.