### PR TITLE
Enhancement rst 4 1 data types

### DIFF
--- a/davitpy/pydarn/plotting/fan.py
+++ b/davitpy/pydarn/plotting/fan.py
@@ -66,8 +66,8 @@ def plotFan(sTime, rad, interval=60, fileType='fitex', param='velocity',
     interval : Optional[int]
         The the time period to be plotted, in seconds.  default = 60
     fileType : Optional[str]
-        The file type to plot, valid inputs are 'fitex','fitacf', 'lmfit'.
-        default = 'fitex'
+        The file type to plot, valid inputs are 'fitex','fitacf', 'lmfit',
+        'fitacf3'.  default = 'fitex'
     param : Optional[str]
         The parameter to be plotted, valid inputs are 'velocity', 'power',
         'width', 'elevation', 'phi0'.  default = 'velocity'

--- a/davitpy/pydarn/plotting/printRec.py
+++ b/davitpy/pydarn/plotting/printRec.py
@@ -135,7 +135,7 @@ def fitPrintRec(sTime, eTime, rad, outfile, fileType='fitex', summ=0):
     outfile : str
         the txt file we are outputting to
     fileType : Optional[str]
-        the filetype to read, 'fitex','fitacf','lmfit';
+        the filetype to read, 'fitex','fitacf','lmfit', 'fitacf3';
         default = 'fitex'
     summ : Optional[int]
         option to output a beam summary instead of all data

--- a/davitpy/pydarn/plotting/rti.py
+++ b/davitpy/pydarn/plotting/rti.py
@@ -64,8 +64,8 @@ def plot_rti(sTime, rad, eTime=None, bmnum=7, fileType='fitacf',
     bmnum : Optional[int]
         The beam to plot.  default: 7
     fileType : Optional[str]
-        The file type to be plotted, one of ['fitex', 'fitacf', 'lmfit'].
-        default = 'fitex'.
+        The file type to be plotted, one of ['fitex', 'fitacf', 'lmfit',
+        'fitacf3'].  default = 'fitacf'.
     params : Optional[list]
         a list of the fit parameters to plot, allowable values are:
         ['velocity', 'power', 'width', 'elevation', 'phi0'].  default:

--- a/davitpy/pydarn/sdio/radDataRead.py
+++ b/davitpy/pydarn/sdio/radDataRead.py
@@ -68,10 +68,10 @@ def radDataOpen(sTime, radcode, eTime=None, channel=None, bmnum=None, cp=None,
         data from all cp's will be read.  (default=None)
     fileType : (str)
         The type of data you want to read.  valid inputs are: 'fitex','fitacf',
-        'lmfit','rawacf','iqdat'.   If you choose a fit file format and the
-        specified one isn't found, we will search for one of the others.
-        Beware: if you ask for rawacf/iq data, these files are large and the
-        data transfer might take a long time.  (default='fitex')
+        'fitacf3','lmfit','rawacf','iqdat'.   If you choose a fit file format
+        and the specified one isn't found, we will search for one of the
+        others. Beware: if you ask for rawacf/iq data, these files are large
+        and the data transfer might take a long time.  (default='fitex')
     filtered : (boolean)
         A boolean specifying whether you want the fit data to be boxcar
         filtered.  ONLY VALID FOR FIT.  (default=False)

--- a/davitpy/pydarn/sdio/radDataTypes.py
+++ b/davitpy/pydarn/sdio/radDataTypes.py
@@ -61,7 +61,8 @@ class radDataPtr():
     cp : (int)
         control prog id of the request
     fType : (str)
-        the file type, 'fitacf', 'rawacf', 'iqdat', 'fitex', 'lmfit'
+        the file type, 'fitacf', 'fitacf3', 'rawacf', 'iqdat', 'fitex',
+        'lmfit'
     fBeam : (pydarn.sdio.radDataTypes.beamData)
         the first beam of the next scan, useful for when reading into scan
         objects
@@ -138,7 +139,8 @@ class radDataPtr():
         self.__ptr =  None
 
         # check inputs
-        estr = "fileType must be one of: rawacf, fitacf, fitex, lmfit, iqdat"
+        estr = "fileType must be one of: rawacf, fitacf, fitacf3, fitex,"
+        estr += " lmfit, iqdat"
         assert isinstance(self.sTime,dt.datetime), \
             logging.error('sTime must be datetime object')
         assert self.eTime == None or isinstance(self.eTime, dt.datetime), \
@@ -151,8 +153,9 @@ class radDataPtr():
         assert cp == None or isinstance(cp, int), \
             logging.error('cp must be an int or None')
         assert(fileType == 'rawacf' or fileType == 'fitacf' or
-               fileType == 'fitex' or fileType == 'lmfit' or
-               fileType == 'iqdat'), logging.error(estr)
+               fileType == 'fitacf3' or fileType == 'fitex' or
+               fileType == 'lmfit' or fileType == 'iqdat'),
+               logging.error(estr)
         assert fileName == None or isinstance(fileName,str), \
             logging.error('fileName must be None or a string')
         assert isinstance(filtered, bool), \
@@ -172,7 +175,7 @@ class radDataPtr():
         arr = [fileType]
 
         if try_file_types:
-            all_file_types = ['fitex', 'fitacf', 'lmfit']
+            all_file_types = ['fitex', 'fitacf', 'fitacf3', 'lmfit']
             try:
                 all_file_types.pop(all_file_types.index(fileType))
                 arr.extend(all_file_types)
@@ -604,7 +607,7 @@ class radDataPtr():
             return setDmapOffset(self.__fd, offset)
         else:
             if self.recordIndex is None:        
-                self.createIndex()
+               self.createIndex()
             if offset in self.recordIndex.values():
                 return setDmapOffset(self.__fd,offset)
             else:
@@ -826,8 +829,8 @@ class radDataPtr():
                     myBeam.rawacf.updateValsFromDict(dfile)
                 if myBeam.fType == "iqdat":
                     myBeam.iqdat.updateValsFromDict(dfile)
-                if(myBeam.fType == 'fitacf' or myBeam.fType == 'fitex' or
-                   myBeam.fType == 'lmfit'):
+                if(myBeam.fType == 'fitacf' or myBeam.fType == 'fitacf3' or
+                   myBeam.fType == 'fitex' or myBeam.fType == 'lmfit' ):
                     myBeam.fit.updateValsFromDict(dfile)
                 if myBeam.fit.slist == None:
                     myBeam.fit.slist = []
@@ -1144,7 +1147,8 @@ class beamData(radBaseData):
     iqdat : (pydarn.sdio.radDataTypes.iqData)
         iqdat data
     fType : (str)
-        the file type, 'fitacf', 'rawacf', 'iqdat', 'fitex', 'lmfit'
+        the file type, 'fitacf', 'fitacf3' 'rawacf',
+        'iqdat', 'fitex', 'lmfit'
 
     Example
     --------

--- a/davitpy/pydarn/sdio/radDataTypes.py
+++ b/davitpy/pydarn/sdio/radDataTypes.py
@@ -154,7 +154,7 @@ class radDataPtr():
             logging.error('cp must be an int or None')
         assert(fileType == 'rawacf' or fileType == 'fitacf' or
                fileType == 'fitacf3' or fileType == 'fitex' or
-               fileType == 'lmfit' or fileType == 'iqdat'),
+               fileType == 'lmfit' or fileType == 'iqdat'), \
                logging.error(estr)
         assert fileName == None or isinstance(fileName,str), \
             logging.error('fileName must be None or a string')

--- a/davitpy/pydarn/sdio/radDataTypes.py
+++ b/davitpy/pydarn/sdio/radDataTypes.py
@@ -1,16 +1,16 @@
 # Copyright (C) 2012  VT SuperDARN Lab
 # Full license can be found in LICENSE.txt
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -54,7 +54,7 @@ class radDataPtr():
         station id of the request
     channel : (str/NoneType)
         The 1-letter code to specify the UAF channel (not stereo),
-        e.g. 'a','b',... If 'all', ALL channels were obtained. 
+        e.g. 'a','b',... If 'all', ALL channels were obtained.
         (default=None, meaning don't check for UAF named data files)
     bmnum : (int)
         beam number of the request
@@ -76,13 +76,13 @@ class radDataPtr():
     ptr : (file or mongodb query object)
         the data pointer (different depending on mongodo or dmap)
     fd : (int)
-        the file descriptor 
+        the file descriptor
     filtered : (bool)
-        use Filtered datafile 
+        use Filtered datafile
     nocache : (bool)
-        do not use cached files, regenerate tmp files 
+        do not use cached files, regenerate tmp files
     src : (str)
-        local or sftp 
+        local or sftp
 
     Methods
     ----------
@@ -97,14 +97,14 @@ class radDataPtr():
     offsetTell
         Current byte offset
     rewind
-        rewind file back to the beginning 
+        rewind file back to the beginning
     readRec
         read record at current file offset
     readScan
         read scan associated with current record
     readAll
         read all records
-    
+
     Written by AJ 20130108
     """
     def __init__(self, sTime=None, radcode=None, eTime=None, stid=None,
@@ -131,7 +131,7 @@ class radDataPtr():
         self.fBeam = None
         self.recordIndex = None
         self.scanStartIndex = None
-        self.__filename = fileName 
+        self.__filename = fileName
         self.__filtered = filtered
         self.__nocache = noCache
         self.__src = src
@@ -370,7 +370,7 @@ class radDataPtr():
                 logging.info(estr)
                 try:
                     # If the following aren't already, in the near future
-                    # they will be assigned by a configuration dictionary 
+                    # they will be assigned by a configuration dictionary
                     # much like matplotlib's rcsetup.py (matplotlibrc)
                     if remote_site is None:
                         try:
@@ -549,7 +549,7 @@ class radDataPtr():
         return myStr
 
     def __del__(self):
-        self.close() 
+        self.close()
 
     def __iter__(self):
         return self
@@ -592,7 +592,7 @@ class radDataPtr():
                     rectime = dt.datetime.utcfromtimestamp(dfile['time'])
                     recordDict[rectime] = offset
                     if dfile['scan'] == 1: scanStartDict[rectime] = offset
-        # reset back to before building the index 
+        # reset back to before building the index
         self.recordIndex = recordDict
         self.offsetSeek(starting_offset)
         self.scanStartIndex = scanStartDict
@@ -600,13 +600,13 @@ class radDataPtr():
 
     def offsetSeek(self,offset,force=False):
         """jump to dmap record at supplied byte offset.
-        Require offset to be in record index list unless forced. 
+        Require offset to be in record index list unless forced.
         """
         from davitpy.pydarn.dmapio import setDmapOffset, getDmapOffset
         if force:
             return setDmapOffset(self.__fd, offset)
         else:
-            if self.recordIndex is None:        
+            if self.recordIndex is None:
                self.createIndex()
             if offset in self.recordIndex.values():
                 return setDmapOffset(self.__fd,offset)
@@ -614,20 +614,20 @@ class radDataPtr():
                 return getDmapOffset(self.__fd)
 
     def offsetTell(self):
-        """jump to dmap record at supplied byte offset. 
+        """jump to dmap record at supplied byte offset.
         """
         from davitpy.pydarn.dmapio import getDmapOffset
         return getDmapOffset(self.__fd)
 
     def rewind(self):
         """jump to beginning of dmap file."""
-        from davitpy.pydarn.dmapio import setDmapOffset 
+        from davitpy.pydarn.dmapio import setDmapOffset
         return setDmapOffset(self.__fd,0)
 
     def readScan(self, firstBeam=None, useEvery=None, warnNonStandard=True,
                  showBeams=False):
         """A function to read a full scan of data from a
-        :class:`pydarn.sdio.radDataTypes.radDataPtr` object. 
+        :class:`pydarn.sdio.radDataTypes.radDataPtr` object.
         This function is capable of reading standard scans and extracting
         standard scans from patterned or interleaved scans (see Notes).
 
@@ -805,7 +805,7 @@ class radDataPtr():
                 logging.info('reached end of data')
                 #self.close()
                 return None
-            # check that we're in the time window, and that we have a 
+            # check that we're in the time window, and that we have a
             # match for the desired params
             # if dfile['channel'] < 2: channel = 'a'  THIS CHECK IS BAD.
             # 'channel' in a dmap file specifies STEREO operation or not.
@@ -922,10 +922,10 @@ class radBaseData():
         Recursively copy contents into a new object
     updateValsFromDict : (func)
         converts a dict from a dmap file to radBaseData
-    
+
     Written by AJ 20130108
     """
-  
+
     def copyData(self,obj):
         """This method is used to recursively copy all of the contents from
         input object to self
@@ -943,7 +943,7 @@ class radBaseData():
         ::
 
         myradBaseData.copyData(radBaseDataObj)
-      
+
         Note
         -----
         In general, users will not need to use this.
@@ -962,7 +962,7 @@ class radBaseData():
     def updateValsFromDict(self, aDict):
         """A function to to fill a radar params structure with the data in a
         dictionary that is returned from the reading of a dmap file
-    
+
         Parameters
         ------------
         aDict : (dict)
@@ -979,14 +979,14 @@ class radBaseData():
         Written by AJ 20121130
         """
         import datetime as dt
-    
+
         # iterate through prmData's attributes
         # REMOVED BY ASR on 11 SEP 2014
         # the channel attribute in fitted files (fitacf, lmfit, fitex) specifies
-        # if the data came from a STEREO radar, so we shouldn't clobber the 
+        # if the data came from a STEREO radar, so we shouldn't clobber the
         # value from the dmap file.
         #    elif(attr == 'channel'):
-        #      if(aDict.has_key('channel')): 
+        #      if(aDict.has_key('channel')):
         #        if(isinstance(aDict.has_key('channel'), int)):
         #          if(aDict['channel'] < 2): self.channel = 'a'
         #          else: self.channel = alpha[aDict['channel']-1]
@@ -1007,7 +1007,7 @@ class radBaseData():
                     self.channel = aDict['channel']
                 continue
             elif attr == 'inttus':
-                if aDict.has_key('intt.us'): 
+                if aDict.has_key('intt.us'):
                     self.inttus = aDict['intt.us']
                 continue
             elif attr == 'inttsc':
@@ -1088,7 +1088,7 @@ class radBaseData():
                 #put in a default value if not another object
                 if(not isinstance(getattr(self, attr), radBaseData)):
                     setattr(self, attr, None)
-          
+
   #def __repr__(self):
     #myStr = ''
     #for key,var in self.__dict__.iteritems():
@@ -1099,11 +1099,11 @@ class radBaseData():
       #else:
         #myStr += key+' = '+str(var)+'\n'
     #return myStr
-    
+
 class scanData(list):
     """a class to contain a radar scan.  Extends list.
     Just a list of :class:`pydarn.sdio.radDataTypes.beamData` objects
-  
+
     Attributes
     ----------
     None
@@ -1119,11 +1119,11 @@ class scanData(list):
 
     def __init__(self):
         pass
-  
+
 class beamData(radBaseData):
     """a class to contain the data from a radar beam sounding,
     extends class :class:`pydarn.sdio.radDataTypes.radBaseData`
-  
+
     Attributes
     -----------
     cp : (int)
@@ -1177,10 +1177,10 @@ class beamData(radBaseData):
         self.rawacf = rawData(parent=self)
         self.prm = prmData()
         self.iqdat = iqData()
-        self.recordDict = None 
+        self.recordDict = None
         self.fType = None
         self.offset = None
-        self.fPtr = None 
+        self.fPtr = None
         #if we are intializing from an object, do that
         if(beamDict != None):
             self.updateValsFromDict(beamDict)
@@ -1238,7 +1238,7 @@ class prmData(radBaseData):
     tfreq : (int)
         transmit freq in kHz
     txpl : (int)
-        transmit pulse length in us 
+        transmit pulse length in us
     ifmode : (int)
         if mode flag
     ptab : (mppul length list)
@@ -1282,7 +1282,7 @@ class prmData(radBaseData):
         self.noisemean = None   #mean noise level
         self.noisesky = None    #sky noise level
         self.noisesearch = None #freq search noise level
-    
+
         #if we are copying a structure, do that
         if(prmDict != None):
             self.updateValsFromDict(prmDict)
@@ -1386,7 +1386,7 @@ class rawData(radBaseData):
     Attributes
     -------------
     pwr0 : (nrang length list)
-        ACF (auto-correlation function) lag 0 power 
+        ACF (auto-correlation function) lag 0 power
     acfd : (nrang x mplgs x 2 length list)
         ACF data
     xcfd : (nrang x mplgs x 2 length list)
@@ -1536,7 +1536,7 @@ if __name__=="__main__":
     if os.path.isfile(expected_path):
         statinfo = os.stat(expected_path)
         print "Actual File Size:  ", statinfo.st_size
-        print "Expected File Size:", expected_filesize 
+        print "Expected File Size:", expected_filesize
         md5sum=hashlib.md5(open(expected_path).read()).hexdigest()
         print "Actual Md5sum:  ", md5sum
         print "Expected Md5sum:", expected_md5sum
@@ -1586,7 +1586,7 @@ if __name__=="__main__":
     if os.path.isfile(expected_path):
         statinfo = os.stat(expected_path)
         print "Actual File Size:  ", statinfo.st_size
-        print "Expected File Size:", expected_filesize 
+        print "Expected File Size:", expected_filesize
         md5sum = hashlib.md5(open(expected_path).read()).hexdigest()
         print "Actual Md5sum:  ",md5sum
         print "Expected Md5sum:",expected_md5sum
@@ -1611,7 +1611,7 @@ if __name__=="__main__":
     except:
         print "record read failed for some reason"
     ptr.close()
-  
+
     del localptr
 
 
@@ -1648,7 +1648,7 @@ if __name__=="__main__":
     if os.path.isfile(expected_path):
         statinfo = os.stat(expected_path)
         print "Actual File Size:  ", statinfo.st_size
-        print "Expected File Size:", expected_filesize 
+        print "Expected File Size:", expected_filesize
         md5sum = hashlib.md5(open(expected_path).read()).hexdigest()
         print "Actual Md5sum:  ", md5sum
         print "Expected Md5sum:", expected_md5sum
@@ -1715,7 +1715,7 @@ if __name__=="__main__":
     if os.path.isfile(expected_path):
         statinfo = os.stat(expected_path)
         print "Actual File Size:  ", statinfo.st_size
-        print "Expected File Size:", expected_filesize 
+        print "Expected File Size:", expected_filesize
         md5sum=hashlib.md5(open(expected_path).read()).hexdigest()
         print "Actual Md5sum:  ", md5sum
         print "Expected Md5sum:", expected_md5sum

--- a/davitpy/pydarn/sdio/radDataTypes.py
+++ b/davitpy/pydarn/sdio/radDataTypes.py
@@ -1749,3 +1749,48 @@ if __name__=="__main__":
     ptr.close()
     del VTptr
 
+    print ""
+    print "Now lets try to grab new file type, fitacf3"
+    rad = 'fhe'
+    channel = None
+    fileType = 'fitacf3'
+    filtered = False
+    sTime = datetime.datetime(2018, 1, 2, 0, 0)
+    eTime = datetime.datetime(2018, 1, 2, 4, 2)
+    expected_filename = "20180102.000000.20180102.040200.fhe.fitacf3"
+    expected_path = os.path.join(tmpdir, expected_filename)
+    expected_filesize = 14922244
+    expected_md5sum = "b8d21d5a612c074cc264f494e4a61b2b"
+    print "Expected File: " + expected_path
+
+    print "\nRunning sftp grab example for radDataPtr."
+    print "Environment variables used:"
+    print "  DB: " + davitpy.rcParams['DB']
+    print "  DB_PORT: " + davitpy.rcParams['DB_PORT']
+    print "  DBREADUSER: " + davitpy.rcParams['DBREADUSER']
+    print "  DBREADPASS: " + davitpy.rcParams['DBREADPASS']
+    print "  DAVIT_REMOTE_DIRFORMAT: {}".format( \
+                                    davitpy.rcParams['DAVIT_REMOTE_DIRFORMAT'])
+    print "  DAVIT_REMOTE_FNAMEFMT: {}".format( \
+                                    davitpy.rcParams['DAVIT_REMOTE_FNAMEFMT'])
+    print "  DAVIT_REMOTE_TIMEINC: " + davitpy.rcParams['DAVIT_REMOTE_TIMEINC']
+    print "  DAVIT_TMPDIR: " + davitpy.rcParams['DAVIT_TMPDIR']
+    src = 'sftp'
+    if os.path.isfile(expected_path):
+        os.remove(expected_path)
+    VTptr = radDataPtr(sTime, rad, eTime=eTime, channel=channel, bmnum=None,
+                       cp=None, fileType=fileType, filtered=filtered, src=src,
+                       noCache=True)
+    if os.path.isfile(expected_path):
+        statinfo = os.stat(expected_path)
+        print "Actual File Size:  ", statinfo.st_size
+        print "Expected File Size:", expected_filesize
+        md5sum=hashlib.md5(open(expected_path).read()).hexdigest()
+        print "Actual Md5sum:  ", md5sum
+        print "Expected Md5sum:", expected_md5sum
+        if expected_md5sum != md5sum:
+            print "Error: Cached dmap file has unexpected md5sum."
+    else:
+        print "Error: Failed to create expected cache file"
+
+

--- a/davitpy/pydarn/sdio/sdDataRead.py
+++ b/davitpy/pydarn/sdio/sdDataRead.py
@@ -1,16 +1,16 @@
 # Copyright (C) 2012  VT SuperDARN Lab
 # Full license can be found in LICENSE.txt
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -120,13 +120,13 @@ def sdDataOpen(stime, hemi='north', eTime=None, src=None, fileName=None,
     -------
     The evironment variables are python dictionary capable formatted strings
     appended encode radar name, channel, and/or date information. Currently
-    supported dictionary keys which can be used are: 
+    supported dictionary keys which can be used are:
 
     'date'    : datetime.datetime.strftime("%Y%m%d")
-    'year'    : 0 padded 4 digit year 
-    'month'   : 0 padded 2 digit month 
-    'day'     : 0 padded 2 digit day 
-    'hour'    : 0 padded 2 digit day 
+    'year'    : 0 padded 4 digit year
+    'month'   : 0 padded 2 digit month
+    'day'     : 0 padded 2 digit day
+    'hour'    : 0 padded 2 digit day
     'ftype'   : filetype string
     'hemi'    : hemisphere
 
@@ -162,7 +162,7 @@ def sdDataReadRec(my_ptr):
     Example
     --------
     ::
-    
+
     import datetime as dt
     my_ptr = sdDataOpen(dt.datetime(2011,1,1), 'south')
     my_data = sdDataReadRec(my_ptr)
@@ -178,7 +178,7 @@ def sdDataReadRec(my_ptr):
     assert isinstance(my_ptr, sdDataPtr), \
         logging.error('input must be of type sdDataPtr')
 
-    return my_ptr.readRec() 
+    return my_ptr.readRec()
 
 def sdDataCreateIndex(my_ptr):
     """A function to index radar data into dict from a sdDataPtr object
@@ -192,7 +192,7 @@ def sdDataCreateIndex(my_ptr):
     ----------
     my_index : (dict)
         Keys are record timedate objects and values are byte offsets into the
-        file. 
+        file.
 
     Example
     --------
@@ -231,7 +231,7 @@ def sdDataReadAll(my_ptr):
     my_list : (list or NoneType)
         A list filled with gridData or mapData objects holding the data we are
         after.  Vill return None if nothing is found.
- 
+
     Examples
     ---------
     ::

--- a/davitpy/pydarn/sdio/sdDataRead.py
+++ b/davitpy/pydarn/sdio/sdDataRead.py
@@ -32,7 +32,7 @@ sdDataReadAll
 import logging
 
 def sdDataOpen(stime, hemi='north', eTime=None, src=None, fileName=None,
-               fileType='grdex', noCache=False, local_dirfmt=None,
+               fileType='grid2', noCache=False, local_dirfmt=None,
                local_fnamefmt=None, local_dict=None, remote_dirfmt=None,
                remote_fnamefmt=None, remote_dict=None, remote_site=None,
                username=None, password=None, port=None, tmpdir=None,
@@ -59,9 +59,9 @@ def sdDataOpen(stime, hemi='north', eTime=None, src=None, fileName=None,
         the name of a specific file which you want to open.  (default=None)
     fileType : (str)
         The type of data you want to read.  Valid inputs are 'grd', 'grdex',
-        'map', and 'mapex'.  If you choose a file format and the specified one
-        isn't found, we will search for one of the others (eg mapex instead of
-        map). (default='grdex')
+        'grid2', 'map', 'mapex' and 'map2'.  If you choose a file format and
+        the specified one isn't found, we will search for one of the others
+        (eg mapex instead of map). (default='grid2')
     noCache : (boolean)
         flag to indicate that you do not want to check first for cached files.
         (default=False)

--- a/davitpy/pydarn/sdio/sdDataTypes.py
+++ b/davitpy/pydarn/sdio/sdDataTypes.py
@@ -143,7 +143,7 @@ class sdDataPtr():
                  remote_fnamefmt=None, remote_dict=None, remote_site=None,
                  username=None, password=None, port=None, tmpdir=None,
                  remove=False, try_file_types=True):
-#        from davitpy.pydarn.sdio import sdDataPtr
+#       from davitpy.pydarn.sdio import sdDataPtr
         from davitpy.utils.timeUtils import datetimeToEpoch
         import datetime as dt
         import os
@@ -160,7 +160,7 @@ class sdDataPtr():
         self.dType = None
         self.recordIndex = None
         self.__filename = fileName
-        self.__nocache  = noCache
+        self.__nocache = noCache
         self.__src = src
         self.__fd = None
         self.__ptr = None
@@ -170,26 +170,26 @@ class sdDataPtr():
             logging.error('sTime must be datetime object')
         assert hemi is not None, \
             logging.error("hemi must not be None")
-        assert self.eTime == None or isinstance(self.eTime, dt.datetime), \
+        assert self.eTime is None or isinstance(self.eTime, dt.datetime), \
             logging.error('eTime must be datetime object or None')
         assert(fileType == 'grd' or fileType == 'grdex' or
                fileType == 'map' or fileType == 'mapex' or
                fileType == 'grid2' or fileType == 'map2'), \
             logging.error("fileType must be one of: grd, grdex, grid2, "
                           "map, mapex, or map2")
-        assert fileName == None or isinstance(fileName, str), \
+        assert fileName is None or isinstance(fileName, str), \
             logging.error('fileName must be None or a string')
-        assert src == None or src == 'local' or src == 'sftp', \
+        assert src is None or src == 'local' or src == 'sftp', \
             logging.error('src must be one of: None, local, or sftp')
 
-        if self.eTime == None:
+        if self.eTime is None:
             self.eTime = self.sTime + dt.timedelta(days=1)
 
         filelist = []
         arr = [fileType]
         if try_file_types:
-            file_array = {'grd':['grd', 'grdex', 'grid2'],
-                          'map':['map', 'mapex', 'map2']}
+            file_array = {'grd': ['grd', 'grdex', 'grid2'],
+                          'map': ['map', 'mapex', 'map2']}
 
             try:
                 file_key = fileType[0:3]
@@ -213,7 +213,7 @@ class sdDataPtr():
         cached = False
 
         # First, check if a specific filename was given
-        if fileName != None:
+        if fileName is not None:
             try:
                 if not os.path.isfile(fileName):
                     estr = 'problem reading [{:}]: file does '.format(fileName)
@@ -224,8 +224,9 @@ class sdDataPtr():
                 outname = "{:s}{:d}".format(tmpdir, epoch)
                 if(string.find(fileName, '.bz2') != -1):
                     outname = string.replace(fileName, '.bz2', '')
-                    command = 'bunzip2 -c {:s} > {:s}'.format(fileName, outname)
-                elif(string.find(fileName,'.gz') != -1):
+                    command = 'bunzip2 -c {:s} > {:s}'.format(fileName,
+                                                              outname)
+                elif(string.find(fileName, '.gz') != -1):
                     outname = string.replace(fileName, '.gz', '')
                     command = 'gunzip -c {:s} > {:s}'.format(fileName, outname)
                 else:
@@ -241,11 +242,13 @@ class sdDataPtr():
                 return None
 
         # Next, check for a cached file
-        if fileName == None and not noCache:
+        if fileName is not None and not noCache:
             try:
                 if not cached:
-                    command = "{:s}????????.??????.????????.????".format(tmpdir)
-                    command = "{:s}??.{:s}.{:s}".format(command, hemi, fileType)
+                    command = "{:s}????????.??????.????????.????"\
+                              .format(tmpdir)
+                    command = "{:s}??.{:s}.{:s}".format(command, hemi,
+                                                        fileType)
                     for f in glob.glob(command):
                         try:
                             ff = string.replace(f, tmpdir, '')
@@ -260,7 +263,8 @@ class sdDataPtr():
                             if t1 <= self.sTime and t2 >= self.eTime:
                                 cached = True
                                 filelist.append(f)
-                                logging.info('Found cached file {:s}'.format(f))
+                                logging.info('Found cached file '
+                                             '{:s}'.format(f))
                                 break
                         except Exception, e:
                             logging.warning(e)
@@ -268,7 +272,7 @@ class sdDataPtr():
                 logging.warning(e)
 
         # Next, LOOK LOCALLY FOR FILES
-        if not cached and (src == None or src == 'local') and fileName == None:
+        if not cached and (src is None or src == 'local') and fileName is None:
             try:
                 for ftype in arr:
                     estr = "\nLooking locally for {:s} files ".format(ftype)
@@ -289,7 +293,7 @@ class sdDataPtr():
                             logging.info("{:s}{:s}".format(estr, local_dirfmt))
 
                     if local_dict is None:
-                        local_dict = {'hemi':hemi, 'ftype':ftype}
+                        local_dict = {'hemi': hemi, 'ftype': ftype}
 
                     if 'ftype' in local_dict.keys():
                         local_dict['ftype'] = ftype
@@ -297,7 +301,8 @@ class sdDataPtr():
                     if local_fnamefmt is None:
                         try:
                             local_fnamefmt = \
-                        davitpy.rcParams['DAVIT_SD_LOCAL_FNAMEFMT'].split(',')
+                                davitpy.rcParams['DAVIT_SD_LOCAL_FNAMEFMT']\
+                                .split(',')
                         except:
                             local_fnamefmt = ['{date}.{hemi}.{ftype}']
                             estr = 'Environment variable DAVIT_SD_LOCAL_'
@@ -319,7 +324,8 @@ class sdDataPtr():
                     valid = self.__validate_fetched(temp, self.sTime,
                                                     self.eTime)
                     filelist = [x[0] for x in zip(temp, valid) if x[1]]
-                    invalid_files = [x[0] for x in zip(temp, valid) if not x[1]]
+                    invalid_files = [x[0] for x in zip(temp, valid)
+                                     if not x[1]]
 
                     if len(invalid_files) > 0:
                         for f in invalid_files:
@@ -347,8 +353,8 @@ class sdDataPtr():
                 src = None
 
         # Finally, check the sftp server if we have not yet found files
-        if((src == None or src == 'sftp') and self.__ptr == None and
-           len(filelist) == 0 and fileName == None):
+        if((src is None or src == 'sftp') and self.__ptr is None and
+           len(filelist) == 0 and fileName is None):
             for ftype in arr:
                 estr = 'Looking on the remote SFTP server for '
                 logging.info('{:s}{:s} files'.format(estr, ftype))
@@ -385,7 +391,7 @@ class sdDataPtr():
                     if remote_dirfmt is None:
                         try:
                             remote_dirfmt = \
-                            davitpy.rcParams['DAVIT_SD_REMOTE_DIRFORMAT']
+                                davitpy.rcParams['DAVIT_SD_REMOTE_DIRFORMAT']
                         except:
                             remote_dirfmt = 'data/{year}/{ftype}/{hemi}/'
                             estr = 'Config entry DAVIT_SD_REMOTE_DIRFORMAT not'
@@ -394,7 +400,7 @@ class sdDataPtr():
                             logging.info(estr)
 
                     if remote_dict is None:
-                        remote_dict = {'ftype':ftype, 'hemi':hemi}
+                        remote_dict = {'ftype': ftype, 'hemi': hemi}
 
                     if 'ftype' in remote_dict.keys():
                         remote_dict['ftype'] = ftype
@@ -402,7 +408,8 @@ class sdDataPtr():
                     if remote_fnamefmt is None:
                         try:
                             remote_fnamefmt = \
-                    davitpy.rcParams['DAVIT_SD_REMOTE_FNAMEFMT'].split(',')
+                                davitpy.rcParams['DAVIT_SD_REMOTE_FNAMEFMT']\
+                                .split(',')
                         except:
                             remote_fnamefmt = ['{date}.{hemi}.{ftype}']
                             estr = 'Config entry DAVIT_SD_REMOTE_FNAMEFMT not '
@@ -415,7 +422,8 @@ class sdDataPtr():
                             port = davitpy.rcParams['DB_PORT']
                         except:
                             port = '22'
-                            estr = 'Config entry DB_PORT not set, using default'
+                            estr = 'Config entry DB_PORT not set, using '
+                            estr = '{:s}default'.formart(estr)
                             logging.info('{:s}: {:s}'.format(estr, port))
 
                     outdir = tmpdir
@@ -423,8 +431,9 @@ class sdDataPtr():
                     # Now fetch the files
                     temp = futils.fetch_remote_files(self.sTime, self.eTime,
                                                      'sftp', remote_site,
-                                                     remote_dirfmt, remote_dict,
-                                                     outdir, remote_fnamefmt,
+                                                     remote_dirfmt,
+                                                     remote_dict, outdir,
+                                                     remote_fnamefmt,
                                                      username=username,
                                                      password=password,
                                                      port=port, remove=remove)
@@ -434,7 +443,8 @@ class sdDataPtr():
                     valid = self.__validate_fetched(temp, self.sTime,
                                                     self.eTime)
                     filelist = [x[0] for x in zip(temp, valid) if x[1]]
-                    invalid_files = [x[0] for x in zip(temp, valid) if not x[1]]
+                    invalid_files = [x[0] for x in zip(temp, valid)
+                                     if not x[1]]
 
                     if len(invalid_files) > 0:
                         for f in invalid_files:
@@ -443,7 +453,7 @@ class sdDataPtr():
                             os.system("rm {:s}".format(f))
 
                     # If we have valid files then continue
-                    if len(filelist) > 0 :
+                    if len(filelist) > 0:
                         estr = 'found {:s} data on sftp server'.format(ftype)
                         logging.info(estr)
                         self.fType = ftype
@@ -464,12 +474,12 @@ class sdDataPtr():
             if not cached:
                 logging.info('Concatenating all the files in to one')
                 # choose a temp file name with time span info for cacheing
-                tmpname = '{:s}{:s}.{:s}'.format(tmpdir,
-                                                 self.sTime.strftime("%Y%m%d"),
-                                                 self.sTime.strftime("%H%M%S"))
-                tmpname = '{:s}.{:s}.{:s}'.format(tmpname,
-                                                  self.eTime.strftime("%Y%m%d"),
-                                                  self.eTime.strftime("%H%M%S"))
+                tmpname = '{:s}{:s}.{:s}'\
+                          .format(tmpdir, self.sTime.strftime("%Y%m%d"),
+                                  self.sTime.strftime("%H%M%S"))
+                tmpname = '{:s}.{:s}.{:s}'\
+                          .format(tmpname, self.eTime.strftime("%Y%m%d"),
+                                  self.eTime.strftime("%H%M%S"))
                 tmpname = '{:s}.{:s}.{:s}'.format(tmpname, hemi, fileType)
                 command = "cat {:s} > {:s}".format(string.join(filelist),
                                                    tmpname)
@@ -487,15 +497,15 @@ class sdDataPtr():
             self.__filename = tmpname
             self.open()
 
-        if self.__ptr != None:
-            if self.dType == None:
+        if self.__ptr is not None:
+            if self.dType is None:
                 self.dType = 'dmap'
         else:
             logging.info('Sorry, we could not find any data for you :(')
 
     def __repr__(self):
         my_str = 'sdDataPtr\n'
-        for key,var in self.__dict__.iteritems():
+        for key, var in self.__dict__.iteritems():
             my_str = "{:s}{:s} = {:s}\n".format(my_str, key, str(var))
         return my_str
 
@@ -545,7 +555,7 @@ class sdDataPtr():
                                         int(dfile['start.second']))
                     dfile['time'] = (dtime -
                                      dt.datetime(1970, 1, 1)).total_seconds()
-                except Exception,e:
+                except Exception, e:
                     logging.warning(e)
                     logging.warning('problem reading time from file')
                     break
@@ -602,7 +612,7 @@ class sdDataPtr():
         import datetime as dt
 
         # check input
-        if self.__ptr == None:
+        if self.__ptr is None:
             logging.error('the pointer does not point to any data')
             return None
 
@@ -629,7 +639,7 @@ class sdDataPtr():
                 logging.warning('problem reading time from file')
                 break
 
-            if(dfile == None or
+            if(dfile is None or
                dt.datetime.utcfromtimestamp(dfile['time']) > self.eTime):
                 # if we dont have valid data, clean up, get out
                 logging.info('reached end of data')
@@ -640,11 +650,11 @@ class sdDataPtr():
             if(dt.datetime.utcfromtimestamp(dfile['time']) >= self.sTime and
                dt.datetime.utcfromtimestamp(dfile['time']) <= self.eTime):
                 # fill the beamdata object, checking the file type
-                if self.fType == 'grd' or self.fType == 'grdex'
-                    or self.fType == 'grid2':
+                if (self.fType == 'grd' or self.fType == 'grdex' or
+                        self.fType == 'grid2'):
                     mydata = gridData(dataDict=dfile)
-                elif self.fType == 'map' or self.fType == 'mapex'
-                    or self.fType == 'map2':
+                elif (self.fType == 'map' or self.fType == 'mapex' or
+                        self.fType == 'map2'):
                     mydata = mapData(dataDict=dfile)
                 else:
                     logging.error('unrecognized file type')
@@ -738,9 +748,10 @@ class sdDataPtr():
             if np.size(inds) > 0 or np.size(inde) > 0:
                 valid.append(True)
             else:
-                valid.append(False) # ISSUE 217: FASTER TO NOT USE APPEND
+                valid.append(False)  # ISSUE 217: FASTER TO NOT USE APPEND
 
         return valid
+
 
 class sdBaseData():
     """A base class for the processed SD data types.  This allows for single
@@ -787,7 +798,7 @@ class sdBaseData():
         emt = 1
         esc = 1
 
-        for key,val in adict.iteritems():
+        for key, val in adict.iteritems():
             if key == 'start.year':
                 syr = adict['start.year']
             elif key == 'start.month':
@@ -839,9 +850,10 @@ class sdBaseData():
 
     def __repr__(self):
         mystr = ''
-        for key,val in self.__dict__.iteritems():
+        for key, val in self.__dict__.iteritems():
             mystr = "{:s}{:s} = {:s}\n".format(mystr, str(key), str(val))
         return mystr
+
 
 class gridData(sdBaseData):
     """ a class to contain a record of gridded data, extends sdBaseData
@@ -910,8 +922,9 @@ class gridData(sdBaseData):
         self.vemax = None
         self.vector = sdVector(dataDict=dataDict)
 
-        if dataDict != None:
+        if dataDict is not None:
             self.updateValsFromDict(dataDict)
+
 
 # HERE
 class mapData(sdBaseData):
@@ -1017,8 +1030,9 @@ class mapData(sdBaseData):
         self.Np3 = None
         self.model = sdModel(dataDict=dataDict)
 
-        if(dataDict != None):
+        if(dataDict is not None):
             self.updateValsFromDict(dataDict)
+
 
 class sdVector(sdBaseData):
     """ a class to contain vector records of gridded data, extends sdBaseData
@@ -1068,8 +1082,9 @@ class sdVector(sdBaseData):
         self.wdtmedian = None
         self.wdtsd = None
 
-        if(dataDict != None):
+        if(dataDict is not None):
             self.updateValsFromDict(dataDict)
+
 
 class sdModel(sdBaseData):
     """ a class to contain model records of map poential data, extends
@@ -1099,11 +1114,11 @@ class sdModel(sdBaseData):
         self.boundarymlat = None
         self.boundarymlon = None
 
-        if(dataDict != None):
+        if(dataDict is not None):
             self.updateValsFromDict(dataDict)
 
 # TESTING CODE
-if __name__=="__main__":
+if __name__ == "__main__":
     import os
     import datetime as dt
     import hashlib
@@ -1226,7 +1241,6 @@ if __name__=="__main__":
 
     del localptr
 
-
     hemi = 'south'
     channel = None
     stime = dt.datetime(2017, 7, 10)
@@ -1267,7 +1281,6 @@ if __name__=="__main__":
             print "Error: Cached dmap file has unexpected md5sum."
     else:
         print "Error: Failed to create expected cache file"
-
 
     print ""
     print "Now lets grab the new grid2 file type"
@@ -1312,5 +1325,3 @@ if __name__=="__main__":
             print "Error: Cached dmap file has unexpected md5sum."
     else:
         print "Error: Failed to create expected cache file"
-
-

--- a/davitpy/pydarn/sdio/sdDataTypes.py
+++ b/davitpy/pydarn/sdio/sdDataTypes.py
@@ -1225,3 +1225,92 @@ if __name__=="__main__":
     ptr.close()
 
     del localptr
+
+
+    hemi = 'south'
+    channel = None
+    stime = dt.datetime(2017, 7, 10)
+    etime = dt.datetime(2017, 7, 11, 2)
+    expected_filename = "20170710.000000.20170711.020000.south.map2"
+    expected_path = os.path.join(tmpdir, expected_filename)
+    expected_filesize = 28284376
+    expected_md5sum = "de91b6bc239e0ff069732b1ecba5ecf1"
+    print "Expected File:", expected_path
+
+    print "\nRunning sftp grab example for sdDataPtr."
+    print "Environment variables used:"
+    print "  DB:", davitpy.rcParams['DB']
+    print "  DB_PORT:", davitpy.rcParams['DB_PORT']
+    print "  DBREADUSER:", davitpy.rcParams['DBREADUSER']
+    print "  DBREADPASS:", davitpy.rcParams['DBREADPASS']
+    print "  DAVIT_SD_REMOTE_DIRFORMAT:", \
+        davitpy.rcParams['DAVIT_SD_REMOTE_DIRFORMAT']
+    print "  DAVIT_SD_REMOTE_FNAMEFMT:", \
+        davitpy.rcParams['DAVIT_SD_REMOTE_FNAMEFMT']
+    print "  DAVIT_SD_REMOTE_TIMEINC:", \
+        davitpy.rcParams['DAVIT_SD_REMOTE_TIMEINC']
+    print "  DAVIT_TMPDIR:", davitpy.rcParams['DAVIT_TMPDIR']
+
+    src = 'sftp'
+    if os.path.isfile(expected_path):
+        os.remove(expected_path)
+    vtptr = sdDataPtr(stime, hemi, eTime=etime, fileType='map2', src=src,
+                      noCache=True)
+    if os.path.isfile(expected_path):
+        statinfo = os.stat(expected_path)
+        print "Actual File Size:  ", statinfo.st_size
+        print "Expected File Size:", expected_filesize
+        md5sum = hashlib.md5(open(expected_path).read()).hexdigest()
+        print "Actual Md5sum:  ", md5sum
+        print "Expected Md5sum:", expected_md5sum
+        if expected_md5sum != md5sum:
+            print "Error: Cached dmap file has unexpected md5sum."
+    else:
+        print "Error: Failed to create expected cache file"
+
+
+    print ""
+    print "Now lets grab the new grid2 file type"
+
+    hemi = 'north'
+    channel = None
+    stime = dt.datetime(2017, 7, 10)
+    etime = dt.datetime(2017, 7, 11, 2)
+    expected_filename = "20170710.000000.20170711.020000.north.grid2"
+    expected_path = os.path.join(tmpdir, expected_filename)
+    expected_filesize = 11931978
+    expected_md5sum = "c7f555249fc18244f61bb118cc71b2e1"
+    print "Expected File:", expected_path
+
+    print "\nRunning sftp grab example for sdDataPtr."
+    print "Environment variables used:"
+    print "  DB:", davitpy.rcParams['DB']
+    print "  DB_PORT:", davitpy.rcParams['DB_PORT']
+    print "  DBREADUSER:", davitpy.rcParams['DBREADUSER']
+    print "  DBREADPASS:", davitpy.rcParams['DBREADPASS']
+    print "  DAVIT_SD_REMOTE_DIRFORMAT:", \
+        davitpy.rcParams['DAVIT_SD_REMOTE_DIRFORMAT']
+    print "  DAVIT_SD_REMOTE_FNAMEFMT:", \
+        davitpy.rcParams['DAVIT_SD_REMOTE_FNAMEFMT']
+    print "  DAVIT_SD_REMOTE_TIMEINC:", \
+        davitpy.rcParams['DAVIT_SD_REMOTE_TIMEINC']
+    print "  DAVIT_TMPDIR:", davitpy.rcParams['DAVIT_TMPDIR']
+
+    src = 'sftp'
+    if os.path.isfile(expected_path):
+        os.remove(expected_path)
+    vtptr = sdDataPtr(stime, hemi, eTime=etime, fileType='grid2', src=src,
+                      noCache=True)
+    if os.path.isfile(expected_path):
+        statinfo = os.stat(expected_path)
+        print "Actual File Size:  ", statinfo.st_size
+        print "Expected File Size:", expected_filesize
+        md5sum = hashlib.md5(open(expected_path).read()).hexdigest()
+        print "Actual Md5sum:  ", md5sum
+        print "Expected Md5sum:", expected_md5sum
+        if expected_md5sum != md5sum:
+            print "Error: Cached dmap file has unexpected md5sum."
+    else:
+        print "Error: Failed to create expected cache file"
+
+

--- a/davitpy/pydarn/sdio/sdDataTypes.py
+++ b/davitpy/pydarn/sdio/sdDataTypes.py
@@ -1253,22 +1253,25 @@ if __name__ == "__main__":
 
     print "\nRunning sftp grab example for sdDataPtr."
     print "Environment variables used:"
-    print "  DB:", davitpy.rcParams['DB']
-    print "  DB_PORT:", davitpy.rcParams['DB_PORT']
-    print "  DBREADUSER:", davitpy.rcParams['DBREADUSER']
-    print "  DBREADPASS:", davitpy.rcParams['DBREADPASS']
-    print "  DAVIT_SD_REMOTE_DIRFORMAT:", \
-        davitpy.rcParams['DAVIT_SD_REMOTE_DIRFORMAT']
-    print "  DAVIT_SD_REMOTE_FNAMEFMT:", \
-        davitpy.rcParams['DAVIT_SD_REMOTE_FNAMEFMT']
-    print "  DAVIT_SD_REMOTE_TIMEINC:", \
-        davitpy.rcParams['DAVIT_SD_REMOTE_TIMEINC']
+    print "  DB: sd-data.ece.vt.edu"
+    print "  DB_PORT: 22"
+    print "  DBREADUSER: sd_dbread"
+    print "  DBREADPASS: 5d"
+    print "  DAVIT_SD_REMOTE_DIRFORMAT: " +
+        "data/{year}/{ftype}/{hemi}/"
+    print "  DAVIT_SD_REMOTE_FNAMEFMT:", +
+        "{date}.{hemi}.{ftype}"
+    print "  DAVIT_SD_REMOTE_TIMEINC: 24",
     print "  DAVIT_TMPDIR:", davitpy.rcParams['DAVIT_TMPDIR']
 
     src = 'sftp'
     if os.path.isfile(expected_path):
         os.remove(expected_path)
     vtptr = sdDataPtr(stime, hemi, eTime=etime, fileType='map2', src=src,
+                      remote_dirfmt="data/{year}/{ftype}/{radar}/",
+                      remote_fnamefmt="{date}.{hemi}.{ftype}",
+                      remote_site="sd-data.ece.vt.edu",
+                      username="sd_dbread", password="5d", port=22,
                       noCache=True)
     if os.path.isfile(expected_path):
         statinfo = os.stat(expected_path)

--- a/davitpy/pydarn/sdio/sdDataTypes.py
+++ b/davitpy/pydarn/sdio/sdDataTypes.py
@@ -34,8 +34,6 @@ mapData
 import logging
 from davitpy.utils import twoWayDict
 
-alpha = ['a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q',
-         'r','s','t','u','v','w','x','y','z']
 
 class sdDataPtr():
     """A class which contains a pipeline to a data source

--- a/davitpy/pydarn/sdio/sdDataTypes.py
+++ b/davitpy/pydarn/sdio/sdDataTypes.py
@@ -1120,8 +1120,8 @@ if __name__=="__main__":
     etime = dt.datetime(2012, 7, 11, 2)
     expected_filename = "20120710.000000.20120711.020000.north.mapex"
     expected_path = os.path.join(tmpdir, expected_filename)
-    expected_filesize = 32975826
-    expected_md5sum = "1b0e78cb339e875cc17f82e240ef360f"
+    expected_filesize = 33008910
+    expected_md5sum = "1656c94ca564c9a96821496397eed037"
     print "Expected File:", expected_path
 
     print "\nRunning sftp grab example for sdDataPtr."

--- a/davitpy/pydarn/sdio/sdDataTypes.py
+++ b/davitpy/pydarn/sdio/sdDataTypes.py
@@ -74,6 +74,10 @@ class sdDataPtr():
     remote_dict : Optional[dict]
         dictionary of the hemisphere and file type. Default: use
         the values given for hemi and fileType.
+    remote_site : Optional[str]
+        remote sftp server to use. Default: use value given in
+        rcParams' 'DB' value or 'sd-data.ece.vt.edu' if not set in
+        rcParams.
     username : Optional[str]
         username to use for an sftp connection.  Default: rcParams'
         'DBREADUSER' value.

--- a/davitpy/pydarn/sdio/sdDataTypes.py
+++ b/davitpy/pydarn/sdio/sdDataTypes.py
@@ -642,9 +642,11 @@ class sdDataPtr():
             if(dt.datetime.utcfromtimestamp(dfile['time']) >= self.sTime and
                dt.datetime.utcfromtimestamp(dfile['time']) <= self.eTime):
                 # fill the beamdata object, checking the file type
-                if self.fType == 'grd' or self.fType == 'grdex':
+                if self.fType == 'grd' or self.fType == 'grdex'
+                    or self.fType == 'grid2':
                     mydata = gridData(dataDict=dfile)
-                elif self.fType == 'map' or self.fType == 'mapex':
+                elif self.fType == 'map' or self.fType == 'mapex'
+                    or self.fType == 'map2':
                     mydata = mapData(dataDict=dfile)
                 else:
                     logging.error('unrecognized file type')

--- a/davitpy/pydarn/sdio/sdDataTypes.py
+++ b/davitpy/pydarn/sdio/sdDataTypes.py
@@ -84,7 +84,7 @@ class sdDataPtr():
     password : Optional[str]
         password to use for an sftp connection.  Default: rcParams'
         'DBREADPASS' value.
-    port : Optional[int]
+    port : Optional[str]
         port to use for an sftp connection.  Deafult: rcParams'
         'DB_PORT' value.
     tmpdir : Optional[str]

--- a/davitpy/pydarn/sdio/sdDataTypes.py
+++ b/davitpy/pydarn/sdio/sdDataTypes.py
@@ -1245,6 +1245,8 @@ if __name__ == "__main__":
 
     del localptr
 
+    print ""
+    print "Now lets grab an RST4.1 and later map2 file type"
     hemi = 'south'
     channel = None
     stime = dt.datetime(2017, 7, 10)
@@ -1261,21 +1263,21 @@ if __name__ == "__main__":
     print "  DB_PORT: 22"
     print "  DBREADUSER: sd_dbread"
     print "  DBREADPASS: 5d"
-    print "  DAVIT_SD_REMOTE_DIRFORMAT: " +
+    print "  DAVIT_SD_REMOTE_DIRFORMAT: " + \
         "data/{year}/{ftype}/{hemi}/"
-    print "  DAVIT_SD_REMOTE_FNAMEFMT:", +
+    print "  DAVIT_SD_REMOTE_FNAMEFMT: " + \
         "{date}.{hemi}.{ftype}"
-    print "  DAVIT_SD_REMOTE_TIMEINC: 24",
+    print "  DAVIT_SD_REMOTE_TIMEINC: 24"
     print "  DAVIT_TMPDIR:", davitpy.rcParams['DAVIT_TMPDIR']
 
     src = 'sftp'
     if os.path.isfile(expected_path):
         os.remove(expected_path)
     vtptr = sdDataPtr(stime, hemi, eTime=etime, fileType='map2', src=src,
-                      remote_dirfmt="data/{year}/{ftype}/{radar}/",
+                      remote_dirfmt="data/{year}/{ftype}/{hemi}/",
                       remote_fnamefmt="{date}.{hemi}.{ftype}",
                       remote_site="sd-data.ece.vt.edu",
-                      username="sd_dbread", password="5d", port=22,
+                      username="sd_dbread", password="5d", port="22",
                       noCache=True)
     if os.path.isfile(expected_path):
         statinfo = os.stat(expected_path)
@@ -1290,7 +1292,7 @@ if __name__ == "__main__":
         print "Error: Failed to create expected cache file"
 
     print ""
-    print "Now lets grab the new grid2 file type"
+    print "Now lets grab an RST4.1 and later grid2 file type"
 
     hemi = 'north'
     channel = None
@@ -1304,22 +1306,25 @@ if __name__ == "__main__":
 
     print "\nRunning sftp grab example for sdDataPtr."
     print "Environment variables used:"
-    print "  DB:", davitpy.rcParams['DB']
-    print "  DB_PORT:", davitpy.rcParams['DB_PORT']
-    print "  DBREADUSER:", davitpy.rcParams['DBREADUSER']
-    print "  DBREADPASS:", davitpy.rcParams['DBREADPASS']
-    print "  DAVIT_SD_REMOTE_DIRFORMAT:", \
-        davitpy.rcParams['DAVIT_SD_REMOTE_DIRFORMAT']
-    print "  DAVIT_SD_REMOTE_FNAMEFMT:", \
-        davitpy.rcParams['DAVIT_SD_REMOTE_FNAMEFMT']
-    print "  DAVIT_SD_REMOTE_TIMEINC:", \
-        davitpy.rcParams['DAVIT_SD_REMOTE_TIMEINC']
+    print "  DB: sd-data.ece.vt.edu"
+    print "  DB_PORT: 22"
+    print "  DBREADUSER: sd_dbread"
+    print "  DBREADPASS: 5d"
+    print "  DAVIT_SD_REMOTE_DIRFORMAT: " + \
+        "data/{year}/{ftype}/{hemi}/"
+    print "  DAVIT_SD_REMOTE_FNAMEFMT: " + \
+        "{date}.{hemi}.{ftype}"
+    print "  DAVIT_SD_REMOTE_TIMEINC: 24"
     print "  DAVIT_TMPDIR:", davitpy.rcParams['DAVIT_TMPDIR']
 
     src = 'sftp'
     if os.path.isfile(expected_path):
         os.remove(expected_path)
     vtptr = sdDataPtr(stime, hemi, eTime=etime, fileType='grid2', src=src,
+                      remote_dirfmt="data/{year}/{ftype}/{hemi}/",
+                      remote_fnamefmt="{date}.{hemi}.{ftype}",
+                      remote_site="sd-data.ece.vt.edu",
+                      username="sd_dbread", password="5d", port="22",
                       noCache=True)
     if os.path.isfile(expected_path):
         statinfo = os.stat(expected_path)


### PR DESCRIPTION
This pull request is to update davitpy with the new file types available with RST 4.1.  These are fitacf3 (though optional for now), grid2, and map2.  I've also updated the `sdDataTypes` "unit" test section which must have been out of date when grid/map files were reprocessed.  In addition to fixing the current tests there, I added ones that will pull the new grid2, map2 files as well as added a section to the `radDataTypes` "unit" test section to include pulling a fitacf3 file.  The focus here was mostly to enable the new files types in the `sdio/` directory, but I also added the new files types in some of the documentation in the `plotting/` directory.

Otherwise, please use these codes to test things here:

```
from matplotlib import pyplot as plt
from pylab import *
import datetime as dt
from davitpy import pydarn
#from davitpy.utils import geoPack

t1=dt.datetime(2018,1,17)
t2=dt.datetime(2016,8,22,00,00)

rad='fhe'
bmnum=13
rnglimit=[0, 3500]

fig=pydarn.plotting.rti.plot_rti(t1,rad,bmnum=bmnum,params=['velocity'],coords='rng',yrng=rnglimit,gsct=True, fileType='fitacf3')

#fig.show()
savefig('rti_output.png')

```
results in:
![rti_output](https://user-images.githubusercontent.com/3009489/36740173-a9b01176-1baf-11e8-8be0-3f69303cb92d.png)

```
import datetime
import matplotlib.pyplot as plt
from pylab import *
import davitpy.pydarn.plotting.plotMapGrd
from davitpy.utils import *

fig = plt.figure()
ax = fig.add_subplot(111)

sdate = datetime.datetime(2017,4,3,4,0)
mObj = plotUtils.mapObj(boundinglat=50., gridLabels=True, coords='mag')

mapDatObj = davitpy.pydarn.plotting.plotMapGrd.MapConv(sdate, mObj, ax, grid_type='grid2', map_type='map2')
mapDatObj.overlayMapFitVel()
mapDatObj.overlayCnvCntrs()
mapDatObj.overlayHMB()

savefig('pltMapGrd_test2.png')
```

results in:

![pltmapgrd_test2](https://user-images.githubusercontent.com/3009489/36740196-bd9ced76-1baf-11e8-8507-ccc21464e595.png)

Since theses are new filetypes, there are limited amounts of either on the sd-data.ece.vt.edu server.  Grid2/map2 files are available for mostly of 2017 and fitacf3 files are available from 20171201 to near present (have had to revert to rst4.0 to catch up on old data type reprocessing).
