### PR TITLE
Removing need to resource .bashrc or open/close terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ We need to install some dependencies using a script that makes calls to apt-get 
 
     sudo ./install/debian_dependencies.sh
 
-Note that this script also modifies your ~/.bashrc file to set environment variables identifying the DaViTPy installation location, the SuperDARN database access information, and others.  Because of this, please source your ~/.bashrc file (or close and reopen a new terminal window) to refresh your environment variables.
-
 Next, do the actual davitpy install (from in the davitpy directory):
 
     sudo python setup.py install


### PR DESCRIPTION
Updating the install instructions in the `README.md` file as we're no longer explicitly modifying bash environment variables during the installation.  Though it is true that in order for the hdw.dat data to run properly, you need to set some environment variables which has caused a lot of problems related to that.  Maybe there's a bugfix coming where we need to add those to the davitpyrc file...but that's outside of this PR.

Test is to run through a fresh install and don't close the terminal window at all.