### PR TITLE
Fixed a bug in which tsygTrace would throw IndexError on being run.

### DIFF
--- a/davitpy/models/tsyganenko/__init__.py
+++ b/davitpy/models/tsyganenko/__init__.py
@@ -279,19 +279,19 @@ class tsygTrace(object):
         Re = 6371.2
         
         # Initialize trace array
-        self.l = zeros(len(lat))
+        self.l = zeros(len(lat), dtype = int)
         self.xTrace = zeros((len(lat),2*lmax))
         self.yTrace = self.xTrace.copy()
         self.zTrace = self.xTrace.copy()
-        self.xGsw = self.l.copy()
-        self.yGsw = self.l.copy()
-        self.zGsw = self.l.copy()
-        self.latNH = self.l.copy()
-        self.lonNH = self.l.copy()
-        self.rhoNH = self.l.copy()
-        self.latSH = self.l.copy()
-        self.lonSH = self.l.copy()
-        self.rhoSH = self.l.copy()
+        self.xGsw = zeros(len(lat))
+        self.yGsw = self.xGsw.copy()
+        self.zGsw = self.xGsw.copy()
+        self.latNH = self.xGsw.copy()
+        self.lonNH = self.xGsw.copy()
+        self.rhoNH = self.xGsw.copy()
+        self.latSH = self.xGsw.copy()
+        self.lonSH = self.xGsw.copy()
+        self.rhoSH = self.xGsw.copy()
 
         # And now iterate through the desired points
         for ip in xrange(len(lat)):

--- a/davitpy/models/tsyganenko/__init__.py
+++ b/davitpy/models/tsyganenko/__init__.py
@@ -128,9 +128,10 @@ class tsygTrace(object):
         lmax=5000, rmax=60., rmin=1., dsmax=0.01, err=0.000001):
         from datetime import datetime as pydt
 
-        assert (None not in [lat, lon, rho]) or filename, 'You must provide either (lat, lon, rho) or a filename to read from'
+        assert (lat is not None and lon is not None and rho is not None) or filename,\
+            'You must provide either (lat, lon, rho) or a filename to read from'
 
-        if None not in [lat, lon, rho]: 
+        if (lat is not None and lon is not None and rho is not None):
             self.lat = lat
             self.lon = lon
             self.rho = rho


### PR DESCRIPTION
Numpy now requires array indices to be integers, and won't allow the use of float; the `tsyganenko` submodule predates that. I've updated the code so that it will now run without throwing `IndexError`. (Sorry if I've done this in the wrong way – I've never pull requested before…!)